### PR TITLE
[tooling] replace eslint:fix with plain eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     ]
   },
   "scripts": {
-    "lint:fix": "eslint ./src --fix",
+    "lint": "eslint src",
     "precommit": "lint-staged",
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest"


### PR DESCRIPTION
now that every file has been eslint fixed, and we have lint-staged auto-eslint-fixing, there should never be a reason to run eslint --fix manually again.