### PR TITLE
[NAV] Refine naming structure

### DIFF
--- a/src/scopes/navigation/constants.js
+++ b/src/scopes/navigation/constants.js
@@ -1,9 +1,9 @@
 //@flow
 
 // route names
-export const APPLICATIONS_TAB = 'ApplicationsTab'
-export const GATEWAYS_TAB = 'GatewaysTab'
-export const PROFILE_TAB = 'ProfileTab'
+export const APPLICATIONS = 'Applications'
+export const GATEWAYS = 'Gateways'
+export const PROFILE = 'Profile'
 
 export const APPLICATION_LIST = 'ApplicationList'
 export const APPLICATION_DETAIL = 'ApplicationDetail'
@@ -12,12 +12,17 @@ export const DEVICE_DETAIL = 'DeviceDetail'
 export const GATEWAY_LIST = 'GatewayList'
 export const GATEWAY_DETAIL = 'GatewayDetail'
 
-// tab titles
-export const APPLICATIONS = 'Applications'
 export const DATA = 'Data'
-export const DEVICES = 'Devices'
-export const GATEWAYS = 'Gateways'
 export const OVERVIEW = 'Overview'
-export const PROFILE = 'Profile'
 export const SETTINGS = 'Settings'
 export const TRAFFIC = 'Traffic'
+
+// tab labels
+export const APPLICATIONS_LABEL = 'Applications'
+export const DATA_LABEL = 'Data'
+export const DEVICES_LABEL = 'Devices'
+export const GATEWAYS_LABEL = 'Gateways'
+export const OVERVIEW_LABEL = 'Overview'
+export const PROFILE_LABEL = 'Profile'
+export const SETTINGS_LABEL = 'Settings'
+export const TRAFFIC_LABEL = 'Traffic'

--- a/src/scopes/navigation/navigator.js
+++ b/src/scopes/navigation/navigator.js
@@ -12,23 +12,27 @@ import Profile from '../../screens/Profile'
 import TestScreen from '../../screens/TestScreen'
 
 import {
-  APPLICATIONS,
-  APPLICATIONS_TAB,
   APPLICATION_DETAIL,
   APPLICATION_LIST,
+  APPLICATIONS,
+  APPLICATIONS_LABEL,
   DATA,
+  DATA_LABEL,
   DEVICE_DETAIL,
   DEVICE_LIST,
-  DEVICES,
-  GATEWAYS,
-  GATEWAYS_TAB,
+  DEVICES_LABEL,
   GATEWAY_LIST,
   GATEWAY_DETAIL,
+  GATEWAYS,
+  GATEWAYS_LABEL,
   OVERVIEW,
+  OVERVIEW_LABEL,
   PROFILE,
-  PROFILE_TAB,
+  PROFILE_LABEL,
   SETTINGS,
+  SETTINGS_LABEL,
   TRAFFIC,
+  TRAFFIC_LABEL,
 } from './constants'
 import { LATO_REGULAR, LEAGUE_SPARTAN } from '../../constants/fonts'
 
@@ -37,13 +41,18 @@ const ApplicationDetail = TabNavigator(
     [OVERVIEW]: {
       screen: ApplicationDetailPlaceholder,
       path: '/overview',
+      navigationOptions: {
+        tabBar: {
+          label: OVERVIEW_LABEL,
+        },
+      },
     },
     [DEVICE_LIST]: {
       screen: DeviceList,
       path: '/devices',
       navigationOptions: {
         tabBar: {
-          label: DEVICES,
+          label: DEVICES_LABEL,
         },
       },
     },
@@ -61,10 +70,20 @@ const ApplicationDetail = TabNavigator(
     [DATA]: {
       screen: ApplicationDetailPlaceholder,
       path: '/data',
+      navigationOptions: {
+        tabBar: {
+          label: DATA_LABEL,
+        },
+      },
     },
     [SETTINGS]: {
       screen: ApplicationDetailPlaceholder,
       path: '/settings',
+      navigationOptions: {
+        tabBar: {
+          label: SETTINGS_LABEL,
+        },
+      },
     },
   },
   {
@@ -88,12 +107,27 @@ const DeviceDetail = TabNavigator(
   {
     [OVERVIEW]: {
       screen: DeviceDetailPlaceholder,
+      navigationOptions: {
+        tabBar: {
+          label: OVERVIEW_LABEL,
+        },
+      },
     },
     [DATA]: {
       screen: DeviceDetailPlaceholder,
+      navigationOptions: {
+        tabBar: {
+          label: DATA_LABEL,
+        },
+      },
     },
     [SETTINGS]: {
       screen: DeviceDetailPlaceholder,
+      navigationOptions: {
+        tabBar: {
+          label: SETTINGS_LABEL,
+        },
+      },
     },
   },
   {
@@ -112,12 +146,12 @@ const DeviceDetail = TabNavigator(
   }
 )
 
-const ApplicationsTab = StackNavigator({
+const Applications = StackNavigator({
   [APPLICATION_LIST]: {
     screen: ApplicationList,
     path: '/',
     navigationOptions: {
-      title: APPLICATIONS,
+      title: APPLICATIONS_LABEL,
     },
   },
   [APPLICATION_DETAIL]: {
@@ -132,12 +166,27 @@ const GatewayDetail = TabNavigator(
   {
     [OVERVIEW]: {
       screen: GatewayDetailPlaceholder,
+      navigationOptions: {
+        tabBar: {
+          label: OVERVIEW_LABEL,
+        },
+      },
     },
     [TRAFFIC]: {
       screen: GatewayDetailPlaceholder,
+      navigationOptions: {
+        tabBar: {
+          label: TRAFFIC_LABEL,
+        },
+      },
     },
     [SETTINGS]: {
       screen: GatewayDetailPlaceholder,
+      navigationOptions: {
+        tabBar: {
+          label: SETTINGS_LABEL,
+        },
+      },
     },
   },
   {
@@ -157,12 +206,12 @@ const GatewayDetail = TabNavigator(
   }
 )
 
-const GatewaysTab = StackNavigator({
+const Gateways = StackNavigator({
   [GATEWAY_LIST]: {
     screen: GatewayList,
     path: '/',
     navigationOptions: {
-      title: GATEWAYS,
+      title: GATEWAYS_LABEL,
     },
   },
   [GATEWAY_DETAIL]: {
@@ -174,36 +223,36 @@ const GatewaysTab = StackNavigator({
 // Main app navigator. Define bottom tabs here
 export default (AppNavigator = TabNavigator(
   {
-    [APPLICATIONS_TAB]: {
-      screen: ApplicationsTab,
+    [APPLICATIONS]: {
+      screen: Applications,
       path: '/',
       navigationOptions: {
         tabBar: {
-          label: APPLICATIONS,
+          label: APPLICATIONS_LABEL,
         },
       },
     },
-    [GATEWAYS_TAB]: {
-      screen: GatewaysTab,
+    [GATEWAYS]: {
+      screen: Gateways,
       path: '/gateways',
       navigationOptions: {
         tabBar: {
-          label: GATEWAYS,
+          label: GATEWAYS_LABEL,
         },
       },
     },
-    [PROFILE_TAB]: {
+    [PROFILE]: {
       screen: Profile,
       path: '/profile',
       navigationOptions: {
         tabBar: {
-          label: PROFILE,
+          label: PROFILE_LABEL,
         },
       },
     },
   },
   {
-    order: [APPLICATIONS_TAB, GATEWAYS_TAB, PROFILE_TAB],
+    order: [APPLICATIONS, GATEWAYS, PROFILE],
     tabBarComponent: TabView.TabBarBottom,
     tabBarPosition: 'bottom',
   }

--- a/src/screens/ApplicationDetailPlaceholder.js
+++ b/src/screens/ApplicationDetailPlaceholder.js
@@ -6,6 +6,9 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { LATO_REGULAR } from '../constants/fonts'
 
 export default class ApplicationDetailPlaceholder extends Component {
+  static navigationOptions = {
+    title: ({ state }) => state.params.appName,
+  };
   render() {
     return (
       <View style={styles.container}>

--- a/src/screens/ApplicationList.js
+++ b/src/screens/ApplicationList.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
 import { LATO_REGULAR } from '../constants/fonts'
+import { APPLICATION_DETAIL } from '../scopes/navigation/constants'
 
 export default class ApplicationsList extends Component {
   render() {
@@ -12,21 +13,50 @@ export default class ApplicationsList extends Component {
         <Text style={styles.header}>Application List</Text>
         <TouchableOpacity
           style={{ backgroundColor: '#FF00FF' }}
-          onPress={() => this.props.navigation.navigate('ApplicationDetail')}
+          onPress={() =>
+            this.props.navigation.navigate(APPLICATION_DETAIL, {
+              appName: 'Moisture',
+            })}
         >
-          <Text style={styles.header}>Go To Application Detail</Text>
+          <Text style={styles.header}>Moisture</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={{ backgroundColor: '#FF00FF' }}
-          onPress={() => this.props.navigation.navigate('ApplicationDetail')}
+          onPress={() =>
+            this.props.navigation.navigate(APPLICATION_DETAIL, {
+              appName: 'Temperature',
+            })}
         >
-          <Text style={styles.header}>Go To Application Detail</Text>
+          <Text style={styles.header}>Temperature</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={{ backgroundColor: '#FF00FF' }}
-          onPress={() => this.props.navigation.navigate('ApplicationDetail')}
+          onPress={() =>
+            this.props.navigation.navigate(APPLICATION_DETAIL, {
+              appName: 'Air Quality',
+            })}
         >
-          <Text style={styles.header}>Go To Application Detail</Text>
+          <Text style={styles.header}>Air Quality</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={{
+            position: 'absolute',
+            bottom: 20,
+            right: 20,
+            width: 40,
+            height: 40,
+            alignSelf: 'flex-end',
+            backgroundColor: '#e74c3c',
+            borderRadius: 40,
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+          onPress={() => alert("I'm a form!")}
+        >
+          <Text style={{ fontWeight: 'bold', fontSize: 25, color: 'white' }}>
+            +
+          </Text>
         </TouchableOpacity>
       </View>
     )

--- a/src/screens/DeviceDetailPlaceholder.js
+++ b/src/screens/DeviceDetailPlaceholder.js
@@ -6,12 +6,15 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { LATO_REGULAR } from '../constants/fonts'
 
 export default class DeviceDetailPlaceholder extends Component {
+  static navigationOptions = {
+    title: ({ state }) => state.params.deviceName,
+  };
   render() {
     return (
       <View style={styles.container}>
         <TouchableOpacity>
           <Text style={styles.header}>
-            {`I'm device #${this.props.navigation.state.params.id}!`}
+            {`I'm device #${this.props.navigation.state.params.deviceId}!`}
           </Text>
           <Text>{this.props.navigation.state.key}</Text>
         </TouchableOpacity>

--- a/src/screens/DeviceList.js
+++ b/src/screens/DeviceList.js
@@ -4,38 +4,73 @@ import React, { Component } from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
 import { LATO_REGULAR } from '../constants/fonts'
+import { DEVICE_DETAIL } from '../scopes/navigation/constants'
 
 export default class DeviceList extends Component {
+  static navigationOptions = {
+    title: ({ state }) => state.params.appName,
+  };
   render() {
     return (
       <View style={styles.container}>
         <TouchableOpacity
           style={{ backgroundColor: '#FF00FF' }}
           onPress={() =>
-            this.props.navigation.navigate('DeviceDetail', { id: 1 })}
+            this.props.navigation.navigate(DEVICE_DETAIL, {
+              deviceId: 1,
+              deviceName: 'Sensor1',
+            })}
         >
           <Text style={styles.header}>Go To Device #1 Detail</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={{ backgroundColor: '#FF00FF' }}
           onPress={() =>
-            this.props.navigation.navigate('DeviceDetail', { id: 2 })}
+            this.props.navigation.navigate(DEVICE_DETAIL, {
+              deviceId: 2,
+              deviceName: 'Sensor2',
+            })}
         >
           <Text style={styles.header}>Go To Device #2 Detail</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={{ backgroundColor: '#FF00FF' }}
           onPress={() =>
-            this.props.navigation.navigate('DeviceDetail', { id: 3 })}
+            this.props.navigation.navigate(DEVICE_DETAIL, {
+              deviceId: 3,
+              deviceName: 'Sensor3',
+            })}
         >
           <Text style={styles.header}>Go To Device #3 Detail</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={{ backgroundColor: '#FF00FF' }}
           onPress={() =>
-            this.props.navigation.navigate('DeviceDetail', { id: 4 })}
+            this.props.navigation.navigate(DEVICE_DETAIL, {
+              deviceId: 4,
+              deviceName: 'Sensor4',
+            })}
         >
           <Text style={styles.header}>Go To Device #4 Detail</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={{
+            position: 'absolute',
+            bottom: 20,
+            right: 20,
+            width: 40,
+            height: 40,
+            alignSelf: 'flex-end',
+            backgroundColor: '#e74c3c',
+            borderRadius: 40,
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+          onPress={() => alert("I'm a form!")}
+        >
+          <Text style={{ fontWeight: 'bold', fontSize: 25, color: 'white' }}>
+            +
+          </Text>
         </TouchableOpacity>
       </View>
     )

--- a/src/screens/GatewayDetailPlaceholder.js
+++ b/src/screens/GatewayDetailPlaceholder.js
@@ -4,6 +4,9 @@ import React, { Component } from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 
 export default class GatewayDetailPlaceholder extends Component {
+  static navigationOptions = {
+    title: ({ state }) => state.params.gatewayName,
+  };
   render() {
     return (
       <View style={styles.container}>

--- a/src/screens/GatewayList.js
+++ b/src/screens/GatewayList.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
 import { LATO_REGULAR } from '../constants/fonts'
+import { GATEWAY_DETAIL } from '../scopes/navigation/constants'
 
 export default class GatewayList extends Component {
   render() {
@@ -12,21 +13,52 @@ export default class GatewayList extends Component {
         <Text style={styles.header}>GATEWAY LIST</Text>
         <TouchableOpacity
           style={{ backgroundColor: '#FF00FF' }}
-          onPress={() => this.props.navigation.navigate('GatewayDetail')}
+          onPress={() =>
+            this.props.navigation.navigate(GATEWAY_DETAIL, {
+              gatewayId: 1,
+              gatewayName: 'Home',
+            })}
         >
-          <Text style={styles.header}>Go To Gateway Detail</Text>
+          <Text style={styles.header}>Home Gateway</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={{ backgroundColor: '#FF00FF' }}
-          onPress={() => this.props.navigation.navigate('GatewayDetail')}
+          onPress={() =>
+            this.props.navigation.navigate(GATEWAY_DETAIL, {
+              gatewayId: 2,
+              gatewayName: 'Office',
+            })}
         >
-          <Text style={styles.header}>Go To Gateway Detail</Text>
+          <Text style={styles.header}>Office Gateway</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={{ backgroundColor: '#FF00FF' }}
-          onPress={() => this.props.navigation.navigate('GatewayDetail')}
+          onPress={() =>
+            this.props.navigation.navigate(GATEWAY_DETAIL, {
+              gatewayId: 3,
+              gatewayName: 'Remote',
+            })}
         >
-          <Text style={styles.header}>Go To Gateway Detail</Text>
+          <Text style={styles.header}>Remote Gateway</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={{
+            position: 'absolute',
+            bottom: 20,
+            right: 20,
+            width: 40,
+            height: 40,
+            alignSelf: 'flex-end',
+            backgroundColor: '#e74c3c',
+            borderRadius: 40,
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+          onPress={() => alert("I'm a form!")}
+        >
+          <Text style={{ fontWeight: 'bold', fontSize: 25, color: 'white' }}>
+            +
+          </Text>
         </TouchableOpacity>
       </View>
     )


### PR DESCRIPTION
A potentially-confusing aspect of navigation translation is that we have routeNames that are used under the hood for routing that are often the same english word as the visible label, but serve a different purpose. I landed on suffixing all visible labels with _LABEL, which will be used for translations, while routeNames will remain constant across languages.

NOTE: I refer to tab text as a 'label' and top title as 'title', but in certain cases a label is used as a title -- i.e. 'Applications' is technically a label when it appears on the bottom Tab Bar, but it's a title when you tap on the tab and it appears as the screen title up top. Usually, titles will be set dynamically based on the current Application/Gateway/Device the user is viewing, while tab labels are always consistent.

Also includes a naive hard-coded implementation of setting screen titles based on current Application/Gateway/Device.