### PR TITLE
[Store] Correct order of middleware

### DIFF
--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -12,7 +12,7 @@ import thunk from 'redux-thunk'
 const VERSION = 1
 
 //@TODO exclude logging on provide
-const middleware = [logger, thunk]
+const middleware = [thunk, logger]
 
 const enhancers = applyMiddleware(...middleware)
 const stateManagedReducer = stateManager(rootReducer, { version: VERSION }, {})


### PR DESCRIPTION
Puts logger last to avoid logging thunks