### PR TITLE
[Navigation] Remove labels + add icons

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -25,3 +25,4 @@ rules:
   flowtype/use-flow-type: 2
   no-unused-vars: [2, {vars: all, args: none}]
   jsx-quotes: [2, "prefer-double"]
+  react/prop-types: [2, { skipUndeclared: true }]

--- a/src/scopes/navigation/navigator.js
+++ b/src/scopes/navigation/navigator.js
@@ -1,4 +1,5 @@
 // @flow
+import React from 'react'
 import { TabNavigator, TabView, StackNavigator } from 'react-navigation'
 
 import ApplicationList from '../../screens/ApplicationList'
@@ -9,7 +10,10 @@ import DeviceDetailPlaceholder from '../../screens/DeviceDetailPlaceholder'
 import GatewayList from '../../screens/GatewayList'
 import GatewayDetailPlaceholder from '../../screens/GatewayDetailPlaceholder'
 import Profile from '../../screens/Profile'
-import TestScreen from '../../screens/TestScreen'
+// import TestScreen from '../../screens/TestScreen'
+
+import MaterialIcons from 'react-native-vector-icons/MaterialIcons'
+import Zocial from 'react-native-vector-icons/Zocial'
 
 import {
   APPLICATION_DETAIL,
@@ -34,7 +38,9 @@ import {
   TRAFFIC,
   TRAFFIC_LABEL,
 } from './constants'
-import { LATO_REGULAR, LEAGUE_SPARTAN } from '../../constants/fonts'
+
+import { BLUE } from '../../constants/colors'
+import { LATO_REGULAR } from '../../constants/fonts'
 
 const ApplicationDetail = TabNavigator(
   {
@@ -215,7 +221,7 @@ const Gateways = StackNavigator({
 })
 
 // Main app navigator. Define bottom tabs here
-export default (AppNavigator = TabNavigator(
+const AppNavigator = TabNavigator(
   {
     [APPLICATIONS]: {
       screen: Applications,
@@ -223,6 +229,13 @@ export default (AppNavigator = TabNavigator(
       navigationOptions: {
         tabBar: {
           label: APPLICATIONS_LABEL,
+          icon: ({ tintColor, focused }) => (
+            <Zocial
+              name="buffer"
+              size={20}
+              style={{ color: focused ? BLUE : 'grey' }}
+            />
+          ),
         },
       },
     },
@@ -232,6 +245,13 @@ export default (AppNavigator = TabNavigator(
       navigationOptions: {
         tabBar: {
           label: GATEWAYS_LABEL,
+          icon: ({ tintColor, focused }) => (
+            <MaterialIcons
+              name="router"
+              size={30}
+              style={{ color: focused ? BLUE : 'grey' }}
+            />
+          ),
         },
       },
     },
@@ -241,6 +261,13 @@ export default (AppNavigator = TabNavigator(
       navigationOptions: {
         tabBar: {
           label: PROFILE_LABEL,
+          icon: ({ tintColor, focused }) => (
+            <MaterialIcons
+              name="person"
+              size={30}
+              style={{ color: focused ? BLUE : 'grey' }}
+            />
+          ),
         },
       },
     },
@@ -249,5 +276,11 @@ export default (AppNavigator = TabNavigator(
     order: [APPLICATIONS, GATEWAYS, PROFILE],
     tabBarComponent: TabView.TabBarBottom,
     tabBarPosition: 'bottom',
+    tabBarOptions: {
+      showLabel: false,
+      showIcon: true,
+    },
   }
-))
+)
+
+export default AppNavigator


### PR DESCRIPTION
Using react-intl’s FormattedMessage as labels for the main tab bar sections was causing some layout and functionality issues.

I think it’s best we go with just icons and see if using these labels else proves to be problematic.


## before

![simulator screen shot apr 5 2017 11 28 27 am](https://cloud.githubusercontent.com/assets/3741055/24723279/c7e8969c-19fb-11e7-8647-3a635b12014e.png)

## after

![simulator screen shot apr 5 2017 12 31 00 pm](https://cloud.githubusercontent.com/assets/3741055/24723283/cd47871a-19fb-11e7-90cb-d9ab9c293aac.png)
