### PR TITLE
[Auth] Action to reset state

### DIFF
--- a/src/scopes/auth/actions.js
+++ b/src/scopes/auth/actions.js
@@ -4,13 +4,17 @@ import base64 from 'base-64'
 import queryString from 'query-string'
 
 import { ACCESS_TOKEN_URI } from '../../constants/apiEndpoints'
-import { RECEIVE_AUTH } from './types'
+import { RECEIVE_AUTH, RESET_AUTH } from './types'
 
 import type { AuthPayload, ReceiveAuthAction } from './types'
 import type { Dispatch, GetState } from '../../types/redux'
 
 export function receiveAuth(payload: AuthPayload): ReceiveAuthAction {
   return { type: RECEIVE_AUTH, payload: payload }
+}
+
+export function resetAuth(): resetAuth {
+  return { type: RESET_AUTH }
 }
 
 export function getAccessTokenAsync(event: { url: string }) {

--- a/src/scopes/auth/reducer.js
+++ b/src/scopes/auth/reducer.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { RECEIVE_AUTH } from './types'
+import { RECEIVE_AUTH, RESET_AUTH } from './types'
 
 import type { Action } from '../types'
 
@@ -22,6 +22,9 @@ export default (state: State = initialState, action: Action) => {
   switch (action.type) {
     case RECEIVE_AUTH:
       return { ...state, ...action.payload }
+
+    case RESET_AUTH:
+      return initialState
 
     default:
       return state

--- a/src/scopes/auth/types.js
+++ b/src/scopes/auth/types.js
@@ -13,4 +13,9 @@ export type ReceiveAuthAction = {
   payload: AuthPayload,
 };
 
-export type AuthAction = ReceiveAuthAction;
+export const RESET_AUTH = 'auth/RESET_AUTH'
+export type ResetAuthAction = {
+  type: 'auth/RESET_AUTH',
+};
+
+export type AuthAction = ReceiveAuthAction | ResetAuthAction;

--- a/src/screens/Profile.js
+++ b/src/screens/Profile.js
@@ -2,11 +2,14 @@
 
 import React, { Component } from 'react'
 import { View, Text } from 'react-native'
+import { FormattedMessage } from 'react-intl'
+import { connect } from 'react-redux'
+import * as authActions from '../scopes/auth/actions'
 
 const randomColorValue = () => Math.floor(Math.random() * 255)
 const randomColor = `rgb(${randomColorValue()}, ${randomColorValue()}, ${randomColorValue()})`
 
-export default class Profile extends Component {
+class Profile extends Component {
   render() {
     return (
       <View
@@ -17,8 +20,12 @@ export default class Profile extends Component {
           alignItems: 'center',
         }}
       >
-        <Text>I'm your profile!</Text>
+        <Text onPress={this.props.resetAuth}>
+          <FormattedMessage id="app.action.logout" defaultMessage="Logout" />
+        </Text>
       </View>
     )
   }
 }
+
+export default connect(null, authActions)(Profile)


### PR DESCRIPTION
Adds logout button on Profile screen allowing user to reset auth token back to null and be redirected to SplashHome