### PR TITLE
[ApplicationOverview]

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "base-64": "^0.1.0",
     "lodash": "^4.17.4",
+    "moment": "^2.18.1",
     "query-string": "^4.3.2",
     "react": "16.0.0-alpha.4",
     "react-intl": "^2.2.3",

--- a/src/components/AddButton.js
+++ b/src/components/AddButton.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { Platform, TouchableOpacity } from 'react-native'
 
 import Ionicons from 'react-native-vector-icons/Ionicons'
-import { BLUE } from '../constants/colors'
+import { BLUE, WHITE } from '../constants/colors'
 
 const AddButton = (props: Object) => {
   return (
@@ -12,7 +12,7 @@ const AddButton = (props: Object) => {
       <Ionicons
         name="ios-add"
         size={35}
-        style={{ color: 'white', backgroundColor: 'transparent' }}
+        style={{ color: WHITE, backgroundColor: 'transparent' }}
       />
     </TouchableOpacity>
   )

--- a/src/components/ApplicationListItem.js
+++ b/src/components/ApplicationListItem.js
@@ -3,9 +3,11 @@
 import React, { Component } from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
-import { DARK_ORANGE, LIGHT_ORANGE, ORANGE, WHITE } from '../constants/colors'
+import TagLabel from '../components/TagLabel'
 
 import { APPLICATION_DETAIL } from '../scopes/navigation/constants'
+import { WHITE } from '../constants/colors'
+
 import type { TTNApplication } from '../scopes/content/applications/types'
 
 type Props = {
@@ -28,9 +30,7 @@ export default class ApplicationListItem extends Component {
         onPress={() => this._navigateToSingleApplication(application)}
       >
         <View style={styles.applicationRow}>
-          <View style={[styles.applicationContainer, styles.idContainer]}>
-            <Text style={[styles.idText]}>{application.id}</Text>
-          </View>
+          <TagLabel center orange>{application.id}</TagLabel>
           <View style={[styles.applicationContainer, styles.nameContainer]}>
             <Text>{application.name}</Text>
           </View>
@@ -48,6 +48,7 @@ const styles = StyleSheet.create({
     backgroundColor: WHITE,
     borderRadius: 3,
     flexDirection: 'row',
+    alignItems: 'center',
     justifyContent: 'space-between',
     padding: 10,
     minHeight: 100,
@@ -57,18 +58,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 5,
-  },
-  idContainer: {
-    alignSelf: 'center',
-    backgroundColor: LIGHT_ORANGE,
-    borderBottomColor: ORANGE,
-    borderBottomWidth: 1,
-    borderRadius: 3,
-    width: 120,
-    height: 30,
-  },
-  idText: {
-    color: DARK_ORANGE,
   },
   nameContainer: {
     flex: 1,

--- a/src/components/ContentBlock.js
+++ b/src/components/ContentBlock.js
@@ -1,0 +1,47 @@
+// @flow
+
+import React from 'react'
+import { Text, View } from 'react-native'
+
+import { BLUE, LIGHT_GREY, WHITE } from '../constants/colors'
+import { LEAGUE_SPARTAN } from '../constants/fonts'
+
+type Props = {
+  heading: React.Element<any>,
+  children?: React.Element<any>,
+};
+
+const AddButton = (props: Props) => {
+  return (
+    <View style={styles.container}>
+      <View style={styles.heading}>
+        <Text style={styles.headingText}>{props.heading}</Text>
+      </View>
+      <View style={styles.content}>
+        {props.children}
+      </View>
+    </View>
+  )
+}
+
+export default AddButton
+
+const styles = {
+  container: {
+    backgroundColor: WHITE,
+    margin: 10,
+  },
+  content: {
+    padding: 10,
+  },
+  heading: {
+    backgroundColor: LIGHT_GREY,
+    padding: 10,
+  },
+  headingText: {
+    fontFamily: LEAGUE_SPARTAN,
+    fontSize: 18,
+    letterSpacing: 2,
+    color: BLUE,
+  },
+}

--- a/src/components/TagLabel.js
+++ b/src/components/TagLabel.js
@@ -1,0 +1,50 @@
+// @flow
+
+import React from 'react'
+import { Text, View } from 'react-native'
+
+import {
+  BLUE,
+  DARK_ORANGE,
+  LIGHT_BLUE,
+  LIGHT_ORANGE,
+  ORANGE,
+} from '../constants/colors'
+
+type Props = {
+  center?: boolean,
+  children?: React.Element<any>,
+  orange?: boolean,
+};
+
+const TagLabel = (props: Props) => {
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: props.orange ? LIGHT_ORANGE : LIGHT_BLUE,
+          borderBottomColor: props.orange ? ORANGE : BLUE,
+          alignSelf: props.center ? 'center' : 'flex-start',
+        },
+      ]}
+    >
+      <Text style={{ color: props.orange ? DARK_ORANGE : BLUE }}>
+        {props.children}
+      </Text>
+    </View>
+  )
+}
+
+export default TagLabel
+
+const styles = {
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderBottomWidth: 2,
+    borderRadius: 3,
+    height: 30,
+    padding: 10,
+  },
+}

--- a/src/constants/colors.js
+++ b/src/constants/colors.js
@@ -1,7 +1,9 @@
 // @flow
 
+// Brand
 export const BLUE = '#0D83D0'
 export const DARK_GREY = '#363636'
+export const LIGHT_BLUE = '#D4EAF9'
 export const LIGHT_GREY = '#F7F7F7'
 export const LIGHT_ORANGE = '#FFEECD'
 export const ORANGE = '#FFCB67'

--- a/src/scopes/navigation/navigator.js
+++ b/src/scopes/navigation/navigator.js
@@ -38,7 +38,7 @@ import {
   TRAFFIC_LABEL,
 } from './constants'
 
-import { BLUE } from '../../constants/colors'
+import { BLUE, WHITE } from '../../constants/colors'
 import { LATO_REGULAR } from '../../constants/fonts'
 
 const ApplicationDetail = TabNavigator(
@@ -108,7 +108,7 @@ const ApplicationDetail = TabNavigator(
         backgroundColor: BLUE,
       },
       indicatorStyle: {
-        backgroundColor: 'white',
+        backgroundColor: WHITE,
       },
       scrollEnabled: true,
     },
@@ -159,7 +159,7 @@ const DeviceDetail = TabNavigator(
         backgroundColor: BLUE,
       },
       indicatorStyle: {
-        backgroundColor: 'white',
+        backgroundColor: WHITE,
       },
     },
   }

--- a/src/screens/ApplicationList.js
+++ b/src/screens/ApplicationList.js
@@ -15,7 +15,7 @@ import AddButton from '../components/AddButton'
 import ApplicationListItem from '../components/ApplicationListItem'
 
 import { APPLICATIONS_LABEL } from '../scopes/navigation/constants'
-import { LIGHT_GREY } from '../constants/colors'
+import { LIGHT_GREY, WHITE } from '../constants/colors'
 import { LATO_REGULAR } from '../constants/fonts'
 
 import * as TTNApplicationActions from '../scopes/content/applications/actions'
@@ -49,14 +49,6 @@ class ApplicationsList extends Component {
 
   componentDidMount() {
     this._fetchApplications(true)
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    if (!this.state.isRefreshing && nextState.isRefreshing) {
-      return false
-    } else {
-      return true
-    }
   }
 
   _fetchApplications = async (initialLoad = false) => {
@@ -107,7 +99,7 @@ class ApplicationsList extends Component {
               this.setState({ modalVisible: false })
             }}
           >
-            <Text style={{ color: 'white', fontWeight: 'bold' }}>Cancel</Text>
+            <Text style={{ color: WHITE, fontWeight: 'bold' }}>Cancel</Text>
           </TouchableOpacity>
         </View>
       </Modal>
@@ -167,7 +159,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: LIGHT_GREY,
+    backgroundColor: WHITE,
   },
   header: {
     fontFamily: LATO_REGULAR,

--- a/src/screens/ApplicationOverview.js
+++ b/src/screens/ApplicationOverview.js
@@ -7,13 +7,20 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  View,
 } from 'react-native'
+
+import ContentBlock from '../components/ContentBlock'
+import TagLabel from '../components/TagLabel'
+import { FormattedMessage } from 'react-intl'
 
 import { LATO_REGULAR } from '../constants/fonts'
 import { connect } from 'react-redux'
 
 import * as TTNApplicationActions from '../scopes/content/applications/actions'
 import type { TTNApplication } from '../scopes/content/applications/types'
+
+import moment from 'moment'
 
 type Props = {
   application: TTNApplication,
@@ -64,6 +71,40 @@ class ApplicationDetail extends Component {
       this.setState({ initialLoad: true, devices })
     }
   };
+
+  _renderCollaborators(collaborators) {
+    return collaborators.map(collaborator => {
+      const labels = collaborator.rights.map(right => (
+        <View key={right} style={styles.collaboratorLabels}>
+          <TagLabel>{right}</TagLabel>
+        </View>
+      ))
+      return (
+        <View key={collaborator.username} style={styles.collaborators}>
+          <Text style={styles.collaboratorName}>{collaborator.username}</Text>
+          <View style={styles.labelsWrapper}>{labels}</View>
+        </View>
+      )
+    })
+  }
+
+  _renderAccessKeys(accessKeys) {
+    return accessKeys.map(accessKey => {
+      const labels = accessKey.rights.map(right => (
+        <View key={right} style={styles.collaboratorLabels}>
+          <TagLabel>{right}</TagLabel>
+        </View>
+      ))
+      return (
+        <View key={accessKey.name} style={styles.collaborators}>
+          <Text style={styles.collaboratorName}>{accessKey.name}</Text>
+          {/* <Text style={styles.collaboratorName}>{accessKey.key}</Text> */}
+          <View style={styles.labelsWrapper}>{labels}</View>
+        </View>
+      )
+    })
+  }
+
   render() {
     const { application } = this.props
     if (!this.state.initialLoad) {
@@ -84,36 +125,73 @@ class ApplicationDetail extends Component {
             />
           }
         >
-          <Text style={styles.header}>APPLICATION OVERVIEW</Text>
-          <Text>{application.id}</Text>
-          <Text>{application.name}</Text>
-          <Text>{application.created}</Text>
-          <Text>{application.handler}</Text>
-          <Text style={styles.header}>APPLICATION EUIS</Text>
-          <Text>{application.euis.join(',')}</Text>
-          <Text style={styles.header}>DEVICES</Text>
-          <Text>{this.state.devices.length}</Text>
+          <ContentBlock
+            heading={
+              <FormattedMessage
+                id="app.label.application.overview"
+                defaultMessage="APPLICATION OVERVIEW"
+              />
+            }
+          >
+            <View>
+              <Text style={styles.header}>Application ID</Text>
+              <TagLabel orange>{application.id}</TagLabel>
+            </View>
+            <Text style={styles.header}>Description</Text>
+            <Text>{application.name}</Text>
 
-          <Text style={styles.header}>COLABORATORS</Text>
-          {application.collaborators &&
-            application.collaborators.map((user, i) => (
-              <Text key={i}>
-                {user.username}
-                |
-                {user.rights.map((right, i) => <Text key={i}>{right}|</Text>)}
-              </Text>
-            ))}
-          <Text style={styles.header}>ACCESS KEYS</Text>
-          {application.access_keys &&
-            application.access_keys.map((key, i) => (
-              <Text key={i}>
-                {key.key}
-                |
-                {key.name}
-                |
-                {key.rights.map((right, i) => <Text key={i}>{right}|</Text>)}
-              </Text>
-            ))}
+            <Text style={styles.header}>Created</Text>
+            <Text>{moment(application.created).fromNow()}</Text>
+
+            <Text style={styles.header}>Handler</Text>
+            <Text>{application.handler}</Text>
+
+          </ContentBlock>
+          <ContentBlock
+            heading={
+              <FormattedMessage
+                id="app.label.application.eui"
+                defaultMessage="APPLICATION EUIS"
+              />
+            }
+          >
+            <Text>{application.euis.join(',')}</Text>
+          </ContentBlock>
+
+          <ContentBlock
+            heading={
+              <FormattedMessage
+                id="app.label.application.devices"
+                defaultMessage="DEVICES"
+              />
+            }
+          >
+            <Text>{this.state.devices.length}</Text>
+          </ContentBlock>
+
+          <ContentBlock
+            heading={
+              <FormattedMessage
+                id="app.label.application.collaborators"
+                defaultMessage="COLLABORATORS"
+              />
+            }
+          >
+            {application.collaborators &&
+              this._renderCollaborators(application.collaborators)}
+          </ContentBlock>
+
+          <ContentBlock
+            heading={
+              <FormattedMessage
+                id="app.label.application.accessKeys"
+                defaultMessage="ACCESS KEYS"
+              />
+            }
+          >
+            {application.access_keys &&
+              this._renderAccessKeys(application.access_keys)}
+          </ContentBlock>
         </ScrollView>
       )
     }
@@ -133,6 +211,31 @@ const styles = StyleSheet.create({
   header: {
     fontFamily: LATO_REGULAR,
     color: 'black',
-    fontSize: 30,
+    fontWeight: 'bold',
+    marginVertical: 5,
+  },
+  collaborators: {
+    flex: 1,
+    flexDirection: 'column',
+    marginBottom: 20,
+    alignSelf: 'flex-start',
+  },
+  collaboratorName: {
+    fontWeight: 'bold',
+    marginBottom: 5,
+  },
+  collaboratorLabels: {
+    flexDirection: 'column',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-start',
+    alignSelf: 'flex-start',
+    marginRight: 10,
+    marginBottom: 10,
+  },
+  labelsWrapper: {
+    flex: 1,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
   },
 })

--- a/src/screens/DeviceList.js
+++ b/src/screens/DeviceList.js
@@ -14,7 +14,7 @@ import {
 import AddButton from '../components/AddButton'
 import DeviceListItem from '../components/DeviceListItem'
 
-import { LIGHT_GREY } from '../constants/colors'
+import { LIGHT_GREY, WHITE } from '../constants/colors'
 import { LATO_REGULAR } from '../constants/fonts'
 
 import * as TTNApplicationActions from '../scopes/content/applications/actions'
@@ -47,14 +47,6 @@ class DevicesList extends Component {
 
   componentDidMount() {
     this._fetchApplicationDevices(true)
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    if (!this.state.isRefreshing && nextState.isRefreshing) {
-      return false
-    } else {
-      return true
-    }
   }
 
   _fetchApplicationDevices = async (initialLoad = false) => {
@@ -105,7 +97,7 @@ class DevicesList extends Component {
               this.setState({ modalVisible: false })
             }}
           >
-            <Text style={{ color: 'white', fontWeight: 'bold' }}>Cancel</Text>
+            <Text style={{ color: WHITE, fontWeight: 'bold' }}>Cancel</Text>
           </TouchableOpacity>
         </View>
       </Modal>

--- a/src/screens/GatewayList.js
+++ b/src/screens/GatewayList.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
 import { LATO_REGULAR } from '../constants/fonts'
+import { WHITE } from '../constants/colors'
 import { GATEWAY_DETAIL, GATEWAYS_LABEL } from '../scopes/navigation/constants'
 
 export default class GatewayList extends Component {
@@ -42,7 +43,7 @@ export default class GatewayList extends Component {
                 this.setState({ modalVisible: false })
               }}
             >
-              <Text style={{ color: 'white', fontWeight: 'bold' }}>Cancel</Text>
+              <Text style={{ color: WHITE, fontWeight: 'bold' }}>Cancel</Text>
             </TouchableOpacity>
           </View>
         </Modal>
@@ -93,7 +94,7 @@ export default class GatewayList extends Component {
           }}
           onPress={() => this.setState({ modalVisible: true })}
         >
-          <Text style={{ fontWeight: 'bold', fontSize: 25, color: 'white' }}>
+          <Text style={{ fontWeight: 'bold', fontSize: 25, color: WHITE }}>
             +
           </Text>
         </TouchableOpacity>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4088,6 +4088,10 @@ moment@2.x.x:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.1.tgz#fed9506063f36b10f066c8b59a144d7faebe1d82"
 
+moment@^2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+
 morgan@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.8.1.tgz#f93023d3887bd27b78dfd6023cea7892ee27a4b1"


### PR DESCRIPTION
- Adds <ContentBlock /> component used to create content sections with custom font heading
- Adds <TagLabel /> component that supports orange/blue for app ID, permission tag
- Updates ApplicationOverview to use components mentioned above
- Replace string value ‘white’ with constant throughout entire app


Note: Borders don't seem to be working properly on Android. Not sure why.

Closes https://github.com/async-la/ttn-console/issues/13

## ios

![ios](https://cloud.githubusercontent.com/assets/3741055/24780545/07f16ec0-1aed-11e7-95f7-0ef6b5239595.gif)


## android
![android](https://cloud.githubusercontent.com/assets/3741055/24780548/0c00b6f6-1aed-11e7-81f4-5c788f14ca22.gif)

