### PR TITLE
[MQTT] Initial implementation live data monitoring 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,12 @@ DerivedData
 *.xcuserstate
 project.xcworkspace
 
+# Cocoapods
+ios/Pods
+*.sublime-project
+*.sublime-workspace
+
+
 # Android/IntelliJ
 #
 build/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -131,6 +131,8 @@ dependencies {
     compile project(':react-native-vector-icons')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
+    compile 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.1.0'
+
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/app/src/main/java/com/ttnconsole/MainApplication.java
+++ b/android/app/src/main/java/com/ttnconsole/MainApplication.java
@@ -24,7 +24,8 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
-            new VectorIconsPackage()
+          new TTNMQTTPackage(),
+          new VectorIconsPackage()
       );
     }
   };

--- a/android/app/src/main/java/com/ttnconsole/TTNMQTTModule.java
+++ b/android/app/src/main/java/com/ttnconsole/TTNMQTTModule.java
@@ -1,0 +1,156 @@
+package com.ttnconsole;
+
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+import org.eclipse.paho.client.mqttv3.IMqttActionListener;
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.IMqttToken;
+import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+
+import javax.annotation.Nullable;
+
+public class TTNMQTTModule extends ReactContextBaseJavaModule implements MqttCallback {
+
+  ReactApplicationContext reactContext;
+  MemoryPersistence mememoryPersistence;
+  MqttAsyncClient   client;
+  MqttConnectOptions mqttConnectOptions;
+
+  final static String statusConnected = "CONNECTED";
+  final static String statusClosed = "CLOSED";
+  ;
+  public TTNMQTTModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+    this.reactContext = reactContext;
+  }
+
+  @Override
+  public String getName() {
+    return "TTNMQTT";
+  }
+
+  @ReactMethod
+  public void createSessionAsync(ReadableMap options, final Promise promise) {
+    mqttConnectOptions = new MqttConnectOptions();
+    mqttConnectOptions.setUserName(options.getString("username"));
+    mqttConnectOptions.setPassword(options.getString("password").toCharArray());
+    mememoryPersistence = new MemoryPersistence();
+
+    // Create Client
+    try {
+      client = new MqttAsyncClient("tcp://" + options.getString("host"), "async-llc", mememoryPersistence);
+      client.setCallback(this);
+    } catch(MqttException e) {
+      promise.reject(Integer.toString(e.getReasonCode()), e.getLocalizedMessage());
+    }
+
+    // Create session
+    try {
+      client.connect(mqttConnectOptions, reactContext, new IMqttActionListener() {
+        public void onSuccess(IMqttToken asyncActionToken) {
+          android.util.Log.d("ReactNative", "Connected");
+          promise.resolve(null);
+        }
+
+        public void onFailure(IMqttToken asyncActionToken, Throwable exception) {
+          promise.reject(exception.getLocalizedMessage(), exception.getMessage());
+        }
+      });
+    } catch (MqttException e) {
+      promise.reject(Integer.toString(e.getReasonCode()), e.getLocalizedMessage());
+    }
+  }
+
+
+  @ReactMethod
+  public void subscribeAsync(final String topic, final Promise promise) {
+    try {
+      client.subscribe(topic, 1, reactContext, new IMqttActionListener() {
+        public void onSuccess(IMqttToken asyncActionToken) {
+          android.util.Log.d("ReactNative", "Subscribed");
+          promise.resolve(null);
+        }
+
+        public void onFailure(IMqttToken asyncActionToken, Throwable exception) {
+          promise.reject(exception.getLocalizedMessage(), exception.getMessage());
+        }
+      });
+    } catch (MqttException e) {
+      promise.reject(Integer.toString(e.getReasonCode()), e.getLocalizedMessage());
+    }
+  }
+
+  @ReactMethod
+  public void unsubscribeAsync(String topic, Promise promise) {
+    try {
+      client.unsubscribe(topic);
+    } catch (MqttException e) {
+      promise.reject(Integer.toString(e.getReasonCode()), e.getLocalizedMessage());
+    }
+  }
+
+
+  @ReactMethod
+  public void getSessionStatus(Callback callback) {
+    if (client != null && client.isConnected()) {
+      callback.invoke(null, statusConnected);
+    } else {
+      callback.invoke(null, statusClosed);
+    }
+  }
+
+  @ReactMethod
+  public void destroySessionAsync(Promise promise) {
+    try {
+      client.disconnect();
+      promise.resolve(null);
+    } catch (MqttException e) {
+      promise.reject(Integer.toString(e.getReasonCode()), e.getLocalizedMessage());
+    }
+  }
+
+
+  private void sendEvent(String eventName,
+                         @Nullable String message) {
+    reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+            .emit(eventName, message);
+  }
+
+
+  /****************************************************************/
+  /* Start MqttCallback interface              */
+  /****************************************************************/
+
+  public void messageArrived(String topic, MqttMessage message) {
+    // Called when a message arrives from the server that matches any
+    // subscription made by the client
+    sendEvent("newMessage", new String(message.getPayload()));
+
+  }
+
+  public void connectionLost(Throwable cause) {
+    // Called when the connection to the server has been lost.
+    // An application may choose to implement reconnection
+    // logic at this point. This sample simply exits.
+    sendEvent("connectionLost", null);
+  }
+
+  public void deliveryComplete(IMqttDeliveryToken token) {}
+
+  /****************************************************************/
+  /* End MqttCallback interface              */
+  /****************************************************************/
+
+}

--- a/android/app/src/main/java/com/ttnconsole/TTNMQTTPackage.java
+++ b/android/app/src/main/java/com/ttnconsole/TTNMQTTPackage.java
@@ -1,0 +1,36 @@
+package com.ttnconsole;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.bridge.JavaScriptModule;
+
+public class TTNMQTTPackage implements ReactPackage {
+
+  @Override
+  public List<NativeModule> createNativeModules(
+          ReactApplicationContext reactContext) {
+    List<NativeModule> modules = new ArrayList<NativeModule>();
+
+    modules.add(new TTNMQTTModule(reactContext));
+
+    return modules;
+  }
+
+  @Override
+  public List<Class<? extends JavaScriptModule>> createJSModules() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<ViewManager> createViewManagers(
+          ReactApplicationContext reactContext) {
+    return Collections.emptyList();
+  }
+
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,9 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://repo.eclipse.org/content/repositories/paho-snapshots/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,10 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'TTNConsole' do
+  # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
+  # use_frameworks!
+
+  pod 'MQTTClient'
+
+end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,19 @@
+PODS:
+  - MQTTClient (0.8.7):
+    - MQTTClient/Core (= 0.8.7)
+  - MQTTClient/Core (0.8.7):
+    - MQTTClient/Manager
+    - MQTTClient/Min
+  - MQTTClient/Manager (0.8.7):
+    - MQTTClient/Min
+  - MQTTClient/Min (0.8.7)
+
+DEPENDENCIES:
+  - MQTTClient
+
+SPEC CHECKSUMS:
+  MQTTClient: 2842bdeab5a65eec75e0fcbbbd2a300946690fee
+
+PODFILE CHECKSUM: b124eaf2284feb4bb6facbd310a61e80aff6070e
+
+COCOAPODS: 1.2.0

--- a/ios/TTNConsole.xcodeproj/project.pbxproj
+++ b/ios/TTNConsole.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		112783B61E89C80D0049531B /* Lato-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 112783AD1E89C80D0049531B /* Lato-LightItalic.ttf */; };
 		112783B71E89C80D0049531B /* Lato-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 112783AE1E89C80D0049531B /* Lato-Regular.ttf */; };
 		112783B81E89C80D0049531B /* LeagueSpartan-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 112783AF1E89C80D0049531B /* LeagueSpartan-Bold.otf */; };
+		1198B72F1E97FF7A00BAA9A3 /* TTNMQTT.m in Sources */ = {isa = PBXBuildFile; fileRef = 1198B72E1E97FF7A00BAA9A3 /* TTNMQTT.m */; };
 		133E29F31AD74F7200F7D852 /* libRCTLinking.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C398B91ACF4ADC00677621 /* libRCTLinking.a */; };
 		139105C61AF99C1200B5F7CC /* libRCTSettings.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 139105C11AF99BAD00B5F7CC /* libRCTSettings.a */; };
 		139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 139FDEF41B06529B00C62182 /* libRCTWebSocket.a */; };
@@ -47,6 +48,7 @@
 		34EC611AB38A4AA9A1785E90 /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FAE482AA97D640BC8788F820 /* SimpleLineIcons.ttf */; };
 		5A479638271540ECA3ECFF86 /* MaterialCommunityIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0179AA5811CF43C8BC9A6BAA /* MaterialCommunityIcons.ttf */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
+		7AE8D8476B7E68D38F26DA7D /* libPods-TTNConsole.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4615CA4FECA96623CDAE3231 /* libPods-TTNConsole.a */; };
 		819C951BB36F418E96C62856 /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5867E3E6A03B4B65893FFDB4 /* MaterialIcons.ttf */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		8A2F75CE6551465EB7F2474A /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D965A8EF89F64E4AA54C1FB9 /* EvilIcons.ttf */; };
@@ -277,6 +279,8 @@
 		112783AD1E89C80D0049531B /* Lato-LightItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Lato-LightItalic.ttf"; path = "TTNConsole/Assets/Fonts/Lato-LightItalic.ttf"; sourceTree = "<group>"; };
 		112783AE1E89C80D0049531B /* Lato-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Lato-Regular.ttf"; path = "TTNConsole/Assets/Fonts/Lato-Regular.ttf"; sourceTree = "<group>"; };
 		112783AF1E89C80D0049531B /* LeagueSpartan-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "LeagueSpartan-Bold.otf"; path = "TTNConsole/Assets/Fonts/LeagueSpartan-Bold.otf"; sourceTree = "<group>"; };
+		1198B72D1E97FF7A00BAA9A3 /* TTNMQTT.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTNMQTT.h; path = TTNConsole/Modules/TTNMQTT.h; sourceTree = "<group>"; };
+		1198B72E1E97FF7A00BAA9A3 /* TTNMQTT.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TTNMQTT.m; path = TTNConsole/Modules/TTNMQTT.m; sourceTree = "<group>"; };
 		139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTSettings.xcodeproj; path = "../node_modules/react-native/Libraries/Settings/RCTSettings.xcodeproj"; sourceTree = "<group>"; };
 		139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTWebSocket.xcodeproj; path = "../node_modules/react-native/Libraries/WebSocket/RCTWebSocket.xcodeproj"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* TTNConsole.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TTNConsole.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -292,6 +296,7 @@
 		279EAE2459934829AAB9414E /* Zocial.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Zocial.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Zocial.ttf"; sourceTree = "<group>"; };
 		2D02E47B1E0B4A5D006451C7 /* TTNConsole-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TTNConsole-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D02E4901E0B4A5D006451C7 /* TTNConsole-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TTNConsole-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4615CA4FECA96623CDAE3231 /* libPods-TTNConsole.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TTNConsole.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4FC072E86C194377A3EA121A /* Octicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Octicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Octicons.ttf"; sourceTree = "<group>"; };
 		57F85268FBF940BD853AE777 /* Foundation.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Foundation.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Foundation.ttf"; sourceTree = "<group>"; };
 		5867E3E6A03B4B65893FFDB4 /* MaterialIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf"; sourceTree = "<group>"; };
@@ -299,6 +304,8 @@
 		71C016C8B1F54F229D3A5372 /* Entypo.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Entypo.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Entypo.ttf"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
+		89D9D892B2A7C2030EB33FEF /* Pods-TTNConsole.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TTNConsole.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TTNConsole/Pods-TTNConsole.debug.xcconfig"; sourceTree = "<group>"; };
+		946DAE36859431ABC81D2C73 /* Pods-TTNConsole.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TTNConsole.release.xcconfig"; path = "Pods/Target Support Files/Pods-TTNConsole/Pods-TTNConsole.release.xcconfig"; sourceTree = "<group>"; };
 		A89F57E7C3AF4ABBB4E6BA8C /* FontAwesome.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
 		D965A8EF89F64E4AA54C1FB9 /* EvilIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EvilIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; };
 		E8AA4960030C4AF0973B7EE0 /* RNVectorIcons.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNVectorIcons.xcodeproj; path = "../node_modules/react-native-vector-icons/RNVectorIcons.xcodeproj"; sourceTree = "<group>"; };
@@ -330,6 +337,7 @@
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
 				DC9B90D7377A4864BBDAB52B /* libRNVectorIcons.a in Frameworks */,
+				7AE8D8476B7E68D38F26DA7D /* libPods-TTNConsole.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -449,6 +457,15 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		1198B7121E97FEDA00BAA9A3 /* Modules */ = {
+			isa = PBXGroup;
+			children = (
+				1198B72D1E97FF7A00BAA9A3 /* TTNMQTT.h */,
+				1198B72E1E97FF7A00BAA9A3 /* TTNMQTT.m */,
+			);
+			name = Modules;
+			sourceTree = "<group>";
+		};
 		139105B71AF99BAD00B5F7CC /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -522,6 +539,15 @@
 			name = Resources;
 			sourceTree = "<group>";
 		};
+		6F34F9DCE24E2954E2089FCA /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				89D9D892B2A7C2030EB33FEF /* Pods-TTNConsole.debug.xcconfig */,
+				946DAE36859431ABC81D2C73 /* Pods-TTNConsole.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		78C398B11ACF4ADC00677621 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -563,11 +589,14 @@
 			isa = PBXGroup;
 			children = (
 				112783771E89C2280049531B /* Assets */,
-				13B07FAE1A68108700A75B9A /* TTNConsole */,
+				8A61275DF616F01CED5C6523 /* Frameworks */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
-				00E356EF1AD99517003FC87E /* TTNConsoleTests */,
+				1198B7121E97FEDA00BAA9A3 /* Modules */,
+				6F34F9DCE24E2954E2089FCA /* Pods */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				5FB501B6AA7149F1B7E5E6C9 /* Resources */,
+				13B07FAE1A68108700A75B9A /* TTNConsole */,
+				00E356EF1AD99517003FC87E /* TTNConsoleTests */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -582,6 +611,14 @@
 				2D02E4901E0B4A5D006451C7 /* TTNConsole-tvOSTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		8A61275DF616F01CED5C6523 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				4615CA4FECA96623CDAE3231 /* libPods-TTNConsole.a */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -609,10 +646,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "TTNConsole" */;
 			buildPhases = (
+				A1966E5A2346E55A93FDDF02 /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				208E8561684EF69463476C74 /* [CP] Embed Pods Frameworks */,
+				14D0DF88490900F1956B588C /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -670,7 +710,11 @@
 				TargetAttributes = {
 					00E356ED1AD99517003FC87E = {
 						CreatedOnToolsVersion = 6.2;
+						DevelopmentTeam = G496R7LJ3Q;
 						TestTargetID = 13B07F861A680F5B00A75B9A;
+					};
+					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = G496R7LJ3Q;
 					};
 					2D02E47A1E0B4A5D006451C7 = {
 						CreatedOnToolsVersion = 8.2.1;
@@ -1007,6 +1051,36 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/packager/react-native-xcode.sh";
 		};
+		14D0DF88490900F1956B588C /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TTNConsole/Pods-TTNConsole-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		208E8561684EF69463476C74 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TTNConsole/Pods-TTNConsole-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		2D02E4CB1E0B4B27006451C7 /* Bundle React Native Code And Images */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1020,6 +1094,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/packager/react-native-xcode.sh";
+		};
+		A1966E5A2346E55A93FDDF02 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1037,6 +1126,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				1198B72F1E97FF7A00BAA9A3 /* TTNMQTT.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1090,6 +1180,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = G496R7LJ3Q;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -1120,6 +1211,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = G496R7LJ3Q;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
@@ -1143,10 +1235,12 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 89D9D892B2A7C2030EB33FEF /* Pods-TTNConsole.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
+				DEVELOPMENT_TEAM = G496R7LJ3Q;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
@@ -1166,9 +1260,11 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 946DAE36859431ABC81D2C73 /* Pods-TTNConsole.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = G496R7LJ3Q;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",

--- a/ios/TTNConsole.xcodeproj/xcshareddata/xcschemes/TTNConsole-tvOS.xcscheme
+++ b/ios/TTNConsole.xcodeproj/xcshareddata/xcschemes/TTNConsole-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/ios/TTNConsole.xcodeproj/xcshareddata/xcschemes/TTNConsole.xcscheme
+++ b/ios/TTNConsole.xcodeproj/xcshareddata/xcschemes/TTNConsole.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/ios/TTNConsole.xcworkspace/contents.xcworkspacedata
+++ b/ios/TTNConsole.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:TTNConsole.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ios/TTNConsole/Modules/TTNMQTT.h
+++ b/ios/TTNConsole/Modules/TTNMQTT.h
@@ -1,0 +1,17 @@
+//
+//  TTNMQTT.h
+//  TTNConsole
+//
+//  Created by Christopher Dro on 4/7/17.
+//  Copyright © 2017 Async LLC. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+#import <MQTTClient/MQTTClient.h>
+#import <MQTTClient/MQTTSessionManager.h>
+
+@interface TTNMQTT : RCTEventEmitter <RCTBridgeModule, MQTTSessionDelegate>
+@property (strong, nonatomic) MQTTSession *session;
+@end

--- a/ios/TTNConsole/Modules/TTNMQTT.m
+++ b/ios/TTNConsole/Modules/TTNMQTT.m
@@ -1,0 +1,255 @@
+//
+//  TTNMQTT.m
+//  TTNConsole
+//
+//  Created by Christopher Dro on 4/7/17.
+//  Copyright © 2017 Async LLC. All rights reserved.
+//
+
+#import "TTNMQTT.h"
+#import "MQTTClient.h"
+
+static NSString* statusCreated = @"CREATED";
+static NSString* statusConnecting = @"CONNECTING";
+static NSString* statusConnected = @"CONNECTED";
+static NSString* statusDisconnecting = @"DISCONNECTING";
+static NSString* statusClosed = @"CLOSED";
+static NSString* statusError = @"ERROR";
+
+@implementation TTNMQTT
+
+RCT_EXPORT_MODULE()
+
+@synthesize bridge = _bridge;
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[@"newMessage", @"connectionLost"];
+}
+
+- (instancetype)init
+{
+  if ((self = [super init])) {
+    _session = [[MQTTSession alloc] init];
+    _session.clientId = @"async-llc";
+  }
+  return self;
+}
+
+RCT_EXPORT_METHOD(createSessionAsync:(NSDictionary *)options
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+
+  _session.userName = options[@"username"];
+  _session.password = options[@"password"];
+  _session.delegate = self;
+  
+  
+  [_session connectToHost:options[@"host"] port:1883 usingSSL:NO connectHandler:^(NSError *error) {
+    if (error) {
+      reject(@"createSession", error.localizedDescription, error);
+    } else {
+      resolve(nil);
+    }
+  }];
+}
+
+RCT_EXPORT_METHOD(subscribeAsync:(NSString *) topic
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [_session subscribeToTopic:topic atLevel:1 subscribeHandler:^(NSError *error, NSArray<NSNumber *> *gQoss){
+    if (error) {
+      NSLog(@"Subscription failed %@", error.localizedDescription);
+      reject(@"subscribe", error.localizedDescription, error);
+    } else {
+      resolve(nil);
+    }
+  }];
+}
+
+RCT_EXPORT_METHOD(unsubscribeAsync:(NSString *) topic
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [_session unsubscribeTopic:topic unsubscribeHandler:^(NSError *error) {
+    if (error) {
+      reject(@"unsubscribe", error.localizedDescription, error);
+    } else {
+      NSLog(@"Unsubscription sucessfull");
+      resolve(nil);
+    }
+  }];
+}
+
+
+RCT_EXPORT_METHOD(getSessionStatus:(RCTResponseSenderBlock)callback)
+{
+  switch (_session.status) {
+    case MQTTSessionStatusCreated:
+      callback(@[[NSNull null], statusCreated]);
+      break;
+    case MQTTSessionStatusConnecting:
+      callback(@[[NSNull null], statusConnecting]);
+      break;
+    case MQTTSessionStatusConnected:
+      callback(@[[NSNull null], statusConnected]);
+      break;
+    case MQTTSessionStatusDisconnecting:
+      callback(@[[NSNull null], statusDisconnecting]);
+      break;
+    case MQTTSessionStatusClosed:
+      callback(@[[NSNull null], statusClosed]);
+      break;
+    case MQTTSessionStatusError:
+      callback(@[[NSNull null], statusError]);
+      break;
+  }
+}
+
+
+RCT_EXPORT_METHOD(destroySessionAsync:
+                  (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [_session closeWithDisconnectHandler:^(NSError *error) {
+    if (error) {
+      reject(@"unsubscribe", error.localizedDescription, error);
+    } else {
+      NSLog(@"Disconnect sucessfull");
+      resolve(nil);
+    }
+  }];
+}
+
+/** Session delegate gives your application control over the MQTTSession
+ @note all callback methods are optional
+ */
+
+
+/** gets called when a new message was received
+ @param session the MQTTSession reporting the new message
+ @param data the data received, might be zero length
+ @param topic the topic the data was published to
+ @param qos the qos of the message
+ @param retained indicates if the data retransmitted from server storage
+ @param mid the Message Identifier of the message if qos = 1 or 2, zero otherwise
+ */
+- (void)newMessage:(MQTTSession *)session
+              data:(NSData *)data
+           onTopic:(NSString *)topic
+               qos:(MQTTQosLevel)qos
+          retained:(BOOL)retained
+               mid:(unsigned int)mid
+{
+  [self sendEventWithName:@"newMessage" body: [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]];
+}
+
+
+/** gets called when a connection has been closed
+ @param session the MQTTSession reporting the close
+ */
+- (void)connectionClosed:(MQTTSession *)session {
+  [self sendEventWithName:@"connectionLost" body: nil];
+}
+
+// UNUSED
+
+/** for mqttio-OBJC backward compatibility
+ @param session see newMessage for description
+ @param data see newMessage for description
+ @param topic see newMessage for description
+ */
+- (void)session:(MQTTSession*)session newMessage:(NSData*)data onTopic:(NSString*)topic {}
+
+/** gets called when a connection is established, closed or a problem occurred
+ @param session the MQTTSession reporting the event
+ @param eventCode the code of the event
+ @param error an optional additional error object with additional information
+ */
+- (void)handleEvent:(MQTTSession *)session event:(MQTTSessionEvent)eventCode error:(NSError *)error {}
+
+/** for mqttio-OBJC backward compatibility
+ @param session the MQTTSession reporting the event
+ @param eventCode the code of the event
+ */
+- (void)session:(MQTTSession*)session handleEvent:(MQTTSessionEvent)eventCode {}
+
+/** gets called when a connection has been successfully established
+ @param session the MQTTSession reporting the connect
+ 
+ */
+- (void)connected:(MQTTSession *)session {}
+
+/** gets called when a connection has been successfully established
+ @param session the MQTTSession reporting the connect
+ @param sessionPresent represents the Session Present flag sent by the broker
+ 
+ */
+- (void)connected:(MQTTSession *)session sessionPresent:(BOOL)sessionPresent {}
+
+/** gets called when a connection has been refused
+ @param session the MQTTSession reporting the refusal
+ @param error an optional additional error object with additional information
+ */
+- (void)connectionRefused:(MQTTSession *)session error:(NSError *)error {}
+
+/** gets called when a connection error happened
+ @param session the MQTTSession reporting the connect error
+ @param error an optional additional error object with additional information
+ */
+- (void)connectionError:(MQTTSession *)session error:(NSError *)error {}
+
+/** gets called when an MQTT protocol error happened
+ @param session the MQTTSession reporting the protocol error
+ @param error an optional additional error object with additional information
+ */
+- (void)protocolError:(MQTTSession *)session error:(NSError *)error {}
+
+/** gets called when a published message was actually delivered
+ @param session the MQTTSession reporting the delivery
+ @param msgID the Message Identifier of the delivered message
+ @note this method is called after a publish with qos 1 or 2 only
+ */
+- (void)messageDelivered:(MQTTSession *)session msgID:(UInt16)msgID {}
+
+/** gets called when a subscription is acknowledged by the MQTT broker
+ @param session the MQTTSession reporting the acknowledge
+ @param msgID the Message Identifier of the SUBSCRIBE message
+ @param qoss an array containing the granted QoS(s) related to the SUBSCRIBE message
+ (see subscribeTopic, subscribeTopics)
+ */
+- (void)subAckReceived:(MQTTSession *)session msgID:(UInt16)msgID grantedQoss:(NSArray<NSNumber *> *)qoss {}
+
+/** gets called when an unsubscribe is acknowledged by the MQTT broker
+ @param session the MQTTSession reporting the acknowledge
+ @param msgID the Message Identifier of the UNSUBSCRIBE message
+ */
+- (void)unsubAckReceived:(MQTTSession *)session msgID:(UInt16)msgID {}
+
+/** gets called when a command is sent to the MQTT broker
+ use this for low level monitoring of the MQTT connection
+ @param session the MQTTSession reporting the sent command
+ @param type the MQTT command type
+ @param qos the Quality of Service of the command
+ @param retained the retained status of the command
+ @param duped the duplication status of the command
+ @param mid the Message Identifier of the command
+ @param data the payload data of the command if any, might be zero length
+ */
+- (void)sending:(MQTTSession *)session type:(MQTTCommandType)type qos:(MQTTQosLevel)qos retained:(BOOL)retained duped:(BOOL)duped mid:(UInt16)mid data:(NSData *)data {}
+
+/** gets called when a command is received from the MQTT broker
+ use this for low level monitoring of the MQTT connection
+ @param session the MQTTSession reporting the received command
+ @param type the MQTT command type
+ @param qos the Quality of Service of the command
+ @param retained the retained status of the command
+ @param duped the duplication status of the command
+ @param mid the Message Identifier of the command
+ @param data the payload data of the command if any, might be zero length
+ */
+- (void)received:(MQTTSession *)session type:(MQTTCommandType)type qos:(MQTTQosLevel)qos retained:(BOOL)retained duped:(BOOL)duped mid:(UInt16)mid data:(NSData *)data {}
+
+@end

--- a/src/components/ClearButton.js
+++ b/src/components/ClearButton.js
@@ -1,0 +1,36 @@
+// @flow
+
+import React from 'react'
+import { Platform, TouchableOpacity } from 'react-native'
+
+import Ionicons from 'react-native-vector-icons/Ionicons'
+import { BLUE, WHITE } from '../constants/colors'
+
+const ClearButton = (props: Object) => {
+  return (
+    <TouchableOpacity style={styles.button} onPress={props.onPress}>
+      <Ionicons
+        name="ios-trash-outline"
+        size={25}
+        style={{ color: WHITE, backgroundColor: 'transparent' }}
+      />
+    </TouchableOpacity>
+  )
+}
+
+export default ClearButton
+
+const styles = {
+  button: {
+    position: 'absolute',
+    paddingTop: Platform.OS === 'ios' ? 2 : 0,
+    bottom: 22,
+    right: 22,
+    width: 44,
+    height: 44,
+    backgroundColor: BLUE,
+    borderRadius: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+}

--- a/src/components/DataListItem.js
+++ b/src/components/DataListItem.js
@@ -1,0 +1,91 @@
+// @flow
+
+import React, { Component } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+import FontAwesome from 'react-native-vector-icons/FontAwesome'
+
+import TagLabel from '../components/TagLabel'
+
+import { BLUE, WHITE } from '../constants/colors'
+import { LATO_REGULAR } from '../constants/fonts'
+import { base64toHEX } from '../utils/payloadConverstion'
+import moment from 'moment'
+
+type Props = {
+  data: Object,
+};
+
+export default class DataListItem extends Component {
+  props: Props;
+
+  render() {
+    const { data } = this.props
+    return (
+      <View style={styles.container}>
+        <View style={styles.caret}>
+          <Text style={styles.dataColumnHeading} />
+          <FontAwesome name="caret-up" size={20} style={{ color: BLUE }} />
+        </View>
+        <View style={styles.dataRow}>
+          <View style={styles.dataColumn}>
+            <Text style={styles.dataColumnHeading}>time</Text>
+            <Text style={styles.dataText}>
+              {moment(data.metadata.time).format('HH:mm:ss')}
+            </Text>
+          </View>
+          <View style={styles.dataColumn}>
+            <Text style={styles.dataColumnHeading}>counter</Text>
+            <Text style={styles.dataText}>
+              {data.counter} {data.is_retry ? '(retry)' : ''}
+            </Text>
+          </View>
+          <View style={styles.dataColumn}>
+            <Text style={styles.dataColumnHeading}>port</Text>
+            <Text style={styles.dataText}>{data.port}</Text>
+          </View>
+          <View style={styles.dataColumn}>
+            <Text style={styles.dataColumnHeading}>dev id</Text>
+            <Text style={styles.dataText}>{data.dev_id}</Text>
+          </View>
+          <View style={styles.dataColumn}>
+            <Text style={styles.dataColumnHeading} />
+            <TagLabel>{base64toHEX(data.payload_raw, true)}</TagLabel>
+          </View>
+        </View>
+      </View>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+  },
+  caret: {
+    alignSelf: 'flex-start',
+    marginTop: 10,
+    marginLeft: 10,
+  },
+  dataRow: {
+    backgroundColor: WHITE,
+    borderRadius: 3,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    padding: 10,
+    minHeight: 50,
+  },
+  dataColumn: {
+    marginRight: 15,
+  },
+  dataColumnHeading: {
+    fontFamily: LATO_REGULAR,
+    fontWeight: 'bold',
+    marginBottom: 5,
+    color: BLUE,
+  },
+  dataText: {
+    fontFamily: LATO_REGULAR,
+  },
+})

--- a/src/components/TagLabel.js
+++ b/src/components/TagLabel.js
@@ -11,6 +11,8 @@ import {
   ORANGE,
 } from '../constants/colors'
 
+import { LATO_REGULAR } from '../constants/fonts'
+
 type Props = {
   center?: boolean,
   children?: React.Element<any>,
@@ -29,7 +31,12 @@ const TagLabel = (props: Props) => {
         },
       ]}
     >
-      <Text style={{ color: props.orange ? DARK_ORANGE : BLUE }}>
+      <Text
+        style={{
+          fontFamily: LATO_REGULAR,
+          color: props.orange ? DARK_ORANGE : BLUE,
+        }}
+      >
         {props.children}
       </Text>
     </View>
@@ -42,7 +49,7 @@ const styles = {
   container: {
     justifyContent: 'center',
     alignItems: 'center',
-    borderBottomWidth: 2,
+    borderBottomWidth: 1,
     borderRadius: 3,
     height: 30,
     padding: 10,

--- a/src/constants/mqttConnectionStatus.js
+++ b/src/constants/mqttConnectionStatus.js
@@ -1,0 +1,9 @@
+// @flow
+
+export const CLOSED = 'CLOSED'
+export const CONNECTED = 'CONNECTED'
+export const CONNECTING = 'CONNECTING'
+export const CREATED = 'CREATED'
+export const DISCONNECTING = 'DISCONNECTING'
+export const ERROR = 'ERROR'
+export const UNAUTHORIZED = 'UNAUTHORIZED'

--- a/src/scopes/navigation/navigator.js
+++ b/src/scopes/navigation/navigator.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import { TabNavigator, TabView, StackNavigator } from 'react-navigation'
 
+import ApplicationData from '../../screens/ApplicationData'
 import ApplicationList from '../../screens/ApplicationList'
 import ApplicationOverview from '../../screens/ApplicationOverview'
 import DeviceList from '../../screens/DeviceList'
@@ -73,7 +74,7 @@ const ApplicationDetail = TabNavigator(
     // },
 
     [DATA]: {
-      screen: Profile,
+      screen: ApplicationData,
       path: '/data',
       navigationOptions: {
         tabBar: {

--- a/src/screens/ApplicationData.js
+++ b/src/screens/ApplicationData.js
@@ -1,0 +1,169 @@
+// @flow
+
+import React, { Component } from 'react'
+import {
+  FlatList,
+  NativeEventEmitter,
+  NativeModules,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
+
+import ClearButton from '../components/ClearButton'
+import DataListItem from '../components/DataListItem'
+
+import {
+  CONNECTED,
+  CLOSED,
+  UNAUTHORIZED,
+} from '../constants/mqttConnectionStatus'
+import { LIGHT_GREY, WHITE } from '../constants/colors'
+import { LATO_REGULAR } from '../constants/fonts'
+
+import { connect } from 'react-redux'
+import { getApplicationMQTTHost } from '../utils/dataMonitor'
+import { getMessageUplinkPermission } from '../utils/permissionCheck'
+
+import type { TTNApplication } from '../scopes/content/applications/types'
+
+const { TTNMQTT } = NativeModules
+const TTNMQTTManagerEmitter = new NativeEventEmitter(TTNMQTT)
+
+type Props = {
+  application: TTNApplication,
+};
+
+type State = {
+  connectionStatus: string,
+  data: Array<Object>,
+};
+
+class ApplicationData extends Component {
+  _subscription = () => {};
+  static navigationOptions = {
+    header: ({ state }) => ({
+      title: state.params.appName,
+    }),
+  };
+
+  props: Props;
+  state: State = {
+    connectionStatus: '',
+    data: [],
+  };
+
+  componentDidMount() {
+    const { application } = this.props
+    const messageUplinkPermission = getMessageUplinkPermission(application)
+    if (messageUplinkPermission) {
+      this._createMQTTSession(application, messageUplinkPermission.key)
+    } else {
+      // User doesn't have proper permissions
+      this.setState({ connectionStatus: UNAUTHORIZED })
+    }
+  }
+
+  componentWillUnmount() {
+    this._subscription && this._subscription.remove()
+    TTNMQTT.destroySessionAsync()
+  }
+
+  _createMQTTSession = async (application, key) => {
+    try {
+      const host = getApplicationMQTTHost(application)
+      await TTNMQTT.createSessionAsync({
+        host,
+        username: application.id,
+        password: key,
+      })
+    } catch (err) {
+      console.error(err)
+    }
+    TTNMQTT.subscribeAsync(`${application.id}/devices/+/up`)
+    TTNMQTT.getSessionStatus(this._handleSessionStatusCheck)
+    this._subscription = TTNMQTTManagerEmitter.addListener(
+      'newMessage',
+      this._handleIncommingMessage
+    )
+    this._subscription = TTNMQTTManagerEmitter.addListener(
+      'connectionLost',
+      this._handleConnectionLoss
+    )
+  };
+  _clearData = () => {
+    this.setState({ data: [] })
+  };
+
+  _handleConnectionLoss = () => {
+    this.setState({ connectionStatus: CLOSED })
+  };
+  _handleSessionStatusCheck = (error, status) => {
+    this.setState({ connectionStatus: status })
+  };
+  _handleIncommingMessage = message => {
+    let data = this.state.data
+    let parsedMessage = JSON.parse(message)
+
+    data.unshift(parsedMessage)
+    this.setState({ data })
+  };
+  _renderContent = () => {
+    if (
+      this.state.data.length === 0 && this.state.connectionStatus === CONNECTED
+    ) {
+      return <Text>Listening to Data</Text>
+    } else {
+      return (
+        <FlatList
+          data={this.state.data}
+          initialListSize={this.state.data.length}
+          keyExtractor={item => item.metadata.time}
+          renderItem={({ item }) => <DataListItem data={item} />}
+          ItemSeparatorComponent={Separator}
+          style={styles.list}
+        />
+      )
+    }
+  };
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text>{this.state.connectionStatus}</Text>
+        {this._renderContent()}
+        <ClearButton onPress={this._clearData} />
+      </View>
+    )
+  }
+}
+
+const Separator = () => <View style={styles.separator} />
+
+export default connect((state, props) => ({
+  application: state.content.applications.dictionary[
+    props.navigation.state.params.appId
+  ],
+}))(ApplicationData)
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: WHITE,
+  },
+  header: {
+    fontFamily: LATO_REGULAR,
+    color: 'black',
+    fontSize: 30,
+  },
+  list: {
+    flex: 1,
+    width: '100%',
+  },
+  separator: {
+    height: 1,
+    width: '100%',
+    backgroundColor: LIGHT_GREY,
+  },
+})

--- a/src/utils/dataMonitor.js
+++ b/src/utils/dataMonitor.js
@@ -1,0 +1,18 @@
+// @flow
+
+import type { TTNApplication } from '../scopes/content/applications/types'
+
+const regions = ['eu', 'asia-se', 'brazil', 'us-west']
+
+export function getApplicationMQTTHost(application: TTNApplication) {
+  if (!application.handler) {
+    throw new Error('Application does not have a registered handler.')
+  }
+  const region = application.handler.replace(/ttn-handler-/g, '').trim()
+
+  if (regions.includes(region)) {
+    return region.concat('.thethings.network')
+  } else {
+    throw new Error("Invalid The Things Network region '" + region + "'")
+  }
+}

--- a/src/utils/payloadConverstion.js
+++ b/src/utils/payloadConverstion.js
@@ -1,0 +1,14 @@
+// @flow
+import base64 from 'base-64'
+
+export function base64toHEX(string: string, split: boolean = false) {
+  let raw = base64.decode(string)
+  let HEX = ''
+  for (let i = 0; i < raw.length; i++) {
+    let _hex = raw.charCodeAt(i).toString(16)
+    HEX += _hex.length == 2 ? _hex : '0' + _hex
+  }
+  return split
+    ? HEX.toUpperCase().replace(/(.{2})/g, '$1 ').trim()
+    : HEX.toUpperCase()
+}

--- a/src/utils/permissionCheck.js
+++ b/src/utils/permissionCheck.js
@@ -1,0 +1,12 @@
+// @flow
+
+import type { TTNApplication } from '../scopes/content/applications/types'
+
+export function getMessageUplinkPermission(application: TTNApplication) {
+  return application.access_keys &&
+    application.access_keys.find(accessKey => {
+      return accessKey.rights.find(
+        right => right.indexOf('messages:up') !== -1
+      )
+    })
+}


### PR DESCRIPTION
Currently for ~~~iOS only and is only on~~~ applications data view.

- Create bridge module to communicate with Native SDK
- Utils for converting base64 payloads to hex + permission check to ensure user has proper access key for mqtt connection. Both will be added to as we add more checks/features.
- Create ApplicationData screen with flat list including custom data list item component.

Downside of current implementation is one session at a time, meaning we can only listen to one application at a time. I don’t think that should be of any issue ATM since we our UI is not going to support that anyway.

We’ll need to follow up this PR to improve authorization and connection issues to the user

Closes https://github.com/async-la/ttn-console/issues/20

### Will need to use .xcworkspace for Xcode instead of .xcproject after this has been merged due to the introduction of Cocoapods.


![ios](https://cloud.githubusercontent.com/assets/3741055/24824339/7871d136-1bbe-11e7-96c5-39e3c93581a3.gif)
