### PR TITLE
[sentry] localize script, commit configureSentry

### DIFF
--- a/ios/TTNConsole.xcodeproj/project.pbxproj
+++ b/ios/TTNConsole.xcodeproj/project.pbxproj
@@ -1112,7 +1112,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export SENTRY_ORG=async-kw\nexport SENTRY_PROJECT=ttn-console\nexport SENTRY_AUTH_TOKEN=78544ac4541f4450a8a159ce81fe7298b80fb35009f24cf49435ab43d4b231af\nexport NODE_BINARY=node\n../node_modules/react-native-sentry/bin/bundle-frameworks\nsentry-cli react-native-xcode ../node_modules/react-native/packager/react-native-xcode.sh\nsentry-cli upload-dsym";
+			shellScript = "export SENTRY_ORG=async-kw\nexport SENTRY_PROJECT=ttn-console\nexport SENTRY_AUTH_TOKEN=78544ac4541f4450a8a159ce81fe7298b80fb35009f24cf49435ab43d4b231af\nexport NODE_BINARY=node\n../node_modules/react-native-sentry/bin/bundle-frameworks\n../node_modules/.bin/sentry-cli react-native-xcode ../node_modules/react-native/packager/react-native-xcode.sh\n../node_modules/.bin/sentry-cli upload-dsym";
 		};
 		14D0DF88490900F1956B588C /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "jest": "^19.0.2",
     "lint-staged": "^3.4.0",
     "prettier": "^1.1.0",
-    "react-test-renderer": "~15.4.1"
+    "react-test-renderer": "~15.4.1",
+    "sentry-cli-binary": "^1.4.1"
   },
   "jest": {
     "preset": "react-native"

--- a/src/utils/configureSentry.js
+++ b/src/utils/configureSentry.js
@@ -1,0 +1,9 @@
+// @flow
+
+import { Sentry } from 'react-native-sentry/lib/Sentry'
+
+export default function() {
+  Sentry.config(
+    'https://c301d1166c6d4a5ba1984df20f5a2160:e81d375ff884466ca40f58da0134336e@sentry.io/159098'
+  ).install()
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5317,6 +5317,10 @@ send@0.15.1:
     range-parser "~1.2.0"
     statuses "~1.3.1"
 
+sentry-cli-binary@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sentry-cli-binary/-/sentry-cli-binary-1.4.1.tgz#c4e6ee85d6b6fa0e50b00b0fbc93375e12e2d2b9"
+
 serialize-error@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"


### PR DESCRIPTION
apologize for the botched PR yesterday - I must have been phased

Here is a *much* improved PR
- sentry-cli is now a local npm dependency (remove need for global sentry-cli install)
- commit configureSentry.js
