### PR TITLE
[flow] fixup flow for devices

### DIFF
--- a/src/components/ConfirmAlert.js
+++ b/src/components/ConfirmAlert.js
@@ -8,18 +8,16 @@ type Props = {
   denyButtonTitle: string,
   onConfirm: () => void,
   onDeny: () => void,
-};
+}
 
-const ConfirmAlert = (
-  {
-    title = 'Alert',
-    message = 'Are you sure?',
-    confirmButtonTitle = 'OK',
-    denyButtonTitle = 'Cancel',
-    onConfirm = () => {},
-    onDeny = () => {},
-  }: Props
-) => {
+const ConfirmAlert = ({
+  title = 'Alert',
+  message = 'Are you sure?',
+  confirmButtonTitle = 'OK',
+  denyButtonTitle = 'Cancel',
+  onConfirm = () => any,
+  onDeny = () => any,
+}: Props) => {
   Alert.alert(title, message, [
     { text: denyButtonTitle, onPress: onDeny },
     { text: confirmButtonTitle, onPress: onConfirm },

--- a/src/components/FormInput.js
+++ b/src/components/FormInput.js
@@ -14,13 +14,17 @@ import {
 import ErrorText from './ErrorText'
 
 type Props = {
-  id: any,
+  id?: any,
   multiline?: boolean,
-  onChangeText: (text: string, formInputId: any) => void,
-  onValidate: (isValid: boolean, formInputId: any) => void,
+  onChangeText: (text: string, formInputId: any) => any,
+  onValidate: (isValid: boolean, formInputId: any) => any,
   required?: boolean,
-  validationType: 'email' | 'applicationId' | 'applicationDescription' | 'none',
-  value: string,
+  validationType?:
+    | 'email'
+    | 'applicationId'
+    | 'applicationDescription'
+    | 'none',
+  value: ?string,
 }
 
 class FormInput extends Component {
@@ -67,7 +71,7 @@ class FormInput extends Component {
         break
       case 'email':
       default:
-        isInvalid = required ? !value.length : false
+        isInvalid = required ? !value || !value.length : false
         validationMsg = 'Field cannot be blank'
     }
 

--- a/src/components/RadioButtonPanel.js
+++ b/src/components/RadioButtonPanel.js
@@ -8,14 +8,13 @@ import RadioButton from './RadioButton'
 type RadioOption = {
   label: string,
   value: string,
-};
+}
 
 type Props = {
-  // $FlowIssue Object.values is not type inferred by flow (at render site)
   buttons: Array<RadioOption>,
   onSelect: Function,
-  selected: string,
-};
+  selected: ?string,
+}
 
 const RadioButtonPanel = ({ buttons, onSelect, selected }: Props) => {
   return (

--- a/src/components/SubmitButton.js
+++ b/src/components/SubmitButton.js
@@ -14,7 +14,7 @@ import { LATO_REGULAR } from '../constants/fonts'
 type Props = {
   active: boolean,
   inProgress?: boolean,
-  onPress: () => void,
+  onPress: () => any,
   style?: Object,
   title: string,
 }

--- a/src/components/WarningText.js
+++ b/src/components/WarningText.js
@@ -6,8 +6,8 @@ import { DARK_ORANGE } from '../constants/colors'
 import { LATO_REGULAR } from '../constants/fonts'
 
 type Props = {
-  children: string,
-  style: Object,
+  children?: string,
+  style?: Object,
 }
 
 export default ({ children, style }: Props) => {

--- a/src/scopes/content/applications/types.js
+++ b/src/scopes/content/applications/types.js
@@ -18,12 +18,19 @@ export type Collaborator = {
 
 export type Device = {
   app_eui: ?string,
+  app_id?: string,
   app_key?: string,
+  app_skey?: string,
   description?: ?string,
+  dev_addr?: string,
   dev_eui?: string,
   dev_id: ?string,
   disable_fcnt_check?: boolean,
+  fcnt_down?: string,
+  fcnt_up?: string,
+  last_seen?: string,
   method?: string,
+  nwk_skey?: string,
   uses_32bit_fcnt?: boolean,
 }
 

--- a/src/screens/DeviceList.js
+++ b/src/screens/DeviceList.js
@@ -27,7 +27,7 @@ import { hasDevicesRights } from '../utils/permissionCheck'
 
 type Props = {
   application: Object,
-  getApplicationDevicesAsync: typeof TTNApplicationActions.getApplicationDevicesAsync,
+  getApplicationDevicesAsync: Function,
   navigation: Object,
 }
 

--- a/src/screens/DeviceSettings.js
+++ b/src/screens/DeviceSettings.js
@@ -31,8 +31,9 @@ const BUTTON_SIZE = 60
 
 type Props = {
   navigation: Object,
-  //deleteDeviceAsync: typeof TTNApplicationActions.deleteDeviceAsync
-  //updateDeviceAsync: typeof TTNApplicationActions.updateDeviceAsync
+  getDeviceAsync: Function,
+  deleteDeviceAsync: Function,
+  updateDeviceAsync: Function,
 }
 
 type State = {
@@ -272,7 +273,7 @@ class DeviceSettings extends Component {
                 buttonTitle={`${copy.DELETE} ${copy.DEVICE}`.toUpperCase()}
                 confirm
                 inProgress={this.state.inProgressDelete}
-                itemToDeleteTitle={`${copy.DEVICE} ${device.dev_id}`}
+                itemToDeleteTitle={`${copy.DEVICE} ${device.dev_id || ''}`}
                 onConfirm={this._deleteDevice}
                 onDeny={this._cancelDeleteDevice}
                 style={styles.deleteDeviceButton}


### PR DESCRIPTION
I had a bunch of eslint errors as well that I resolved by turning off rules in eslintrc, but that is not included in this PR.

Some big takewaways:
- it is hard to flow-type thunks. I think this is actually a fundamental issue with the design of redux-thunk and one of many reasons to not use it. But the alternatives are not pragmatic so I think for now we just type prop actions as `Function`
- need to be careful about marking various properties as optional and nullable. There was a few dozen errors from this.
- since async functions always return promises, most generic `onSomething` handlers need to be typed with the `any` return type instead of `void`