### PR TITLE
[TabBar] Avoid floating Tabbar on Android when keyboard present

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,8 +26,7 @@
         android:name=".MainActivity"
         android:launchMode="singleTask"
         android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-        android:windowSoftInputMode="adjustResize">
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
The suggestion on the forum didn't help but removing the entire property seemed to do the trick with no side-effects that I noticed.

I believe this was recently introduced in 0.42 to behave well with KeyboardAvoidingView. Let's just keep an eye out and see if we notice any funky behavior.

Closes https://github.com/async-la/ttn-console/issues/136