### PR TITLE
[ApplicationData] Make sure deviceId param exists

### DIFF
--- a/src/screens/ApplicationData.js
+++ b/src/screens/ApplicationData.js
@@ -52,7 +52,7 @@ class ApplicationData extends Component {
   static navigationOptions = ({ navigation, screenProps }) => ({
     // deviceId supersedes appId
     title: (navigation.state.params && navigation.state.params.deviceId) ||
-      navigation.state.params.appId ||
+      navigation.state.params.appName ||
       '',
     headerRight: navigation.state.params.clearTitle &&
       <View style={styles.clearButton}>


### PR DESCRIPTION
I broke the monitor with all devices with an earlier commit.

This checks to make sure the `deviceId` param is there before doing a comparison with the incoming data.

Also updated navbar to show app name instead of id.