### PR TITLE
[Settings] Consistent DeleteButton, Map tweaks

### DIFF
--- a/src/components/ConfirmAlert.js
+++ b/src/components/ConfirmAlert.js
@@ -8,6 +8,7 @@ type Props = {
   denyButtonTitle?: string,
   onConfirm?: () => any,
   onDeny?: () => any,
+  style?: string,
 }
 
 const ConfirmAlert = ({
@@ -15,12 +16,13 @@ const ConfirmAlert = ({
   message = 'Are you sure?',
   confirmButtonTitle = 'OK',
   denyButtonTitle = 'Cancel',
+  style = 'default',
   onConfirm = () => {},
   onDeny = () => {},
 }: Props) => {
   Alert.alert(title, message, [
-    { text: denyButtonTitle, onPress: onDeny },
-    { text: confirmButtonTitle, onPress: onConfirm },
+    { text: denyButtonTitle, onPress: onDeny, style: 'cancel' },
+    { text: confirmButtonTitle, onPress: onConfirm, style },
   ])
   return null
 }

--- a/src/components/DeleteButton.js
+++ b/src/components/DeleteButton.js
@@ -48,6 +48,7 @@ class DeleteButton extends Component {
       denyButtonTitle: copy.CANCEL,
       onConfirm,
       onDeny,
+      style: 'destructive',
     })
   }
   _onPress = () => {

--- a/src/screens/ApplicationSettings.js
+++ b/src/screens/ApplicationSettings.js
@@ -454,6 +454,7 @@ class ApplicationSettings extends Component {
           {applicationHasDeleteRights(application) &&
             <DeleteButton
               title="DELETE APPLICATION"
+              small
               confirm
               inProgress={this.state.inProgressDelete}
               itemToDeleteTitle={`application ${application.id}`}
@@ -528,15 +529,14 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
   submitButton: {
-    width: BUTTON_SIZE * 2,
+    width: BUTTON_SIZE * 3,
     height: BUTTON_SIZE,
     marginBottom: 15,
+    alignSelf: 'flex-end',
   },
   deleteButton: {
-    width: BUTTON_SIZE * 4,
-    height: BUTTON_SIZE,
     alignSelf: 'center',
-    marginBottom: 15,
+    marginVertical: 30,
   },
   euiRow: {
     flexDirection: 'row',

--- a/src/screens/DeviceSettings.js
+++ b/src/screens/DeviceSettings.js
@@ -266,16 +266,6 @@ class DeviceSettings extends Component {
                 />
                 {!this.state.frameCounterChecks &&
                   <WarningText>{copy.FRAME_COUNTER_CHECK_WARNING}</WarningText>}
-                <DeleteButton
-                  title={`${copy.DELETE} ${copy.DEVICE}`.toUpperCase()}
-                  confirm
-                  small
-                  inProgress={this.state.inProgressDelete}
-                  itemToDeleteTitle={`${copy.DEVICE} ${device.dev_id || ''}`}
-                  onConfirm={this._deleteDevice}
-                  onDeny={this._cancelDeleteDevice}
-                  style={styles.deleteDeviceButton}
-                />
 
                 <SubmitButton
                   active={this._settingsHaveChanged()}
@@ -285,6 +275,17 @@ class DeviceSettings extends Component {
                   title={copy.SAVE}
                 />
               </ContentBlock>
+
+              <DeleteButton
+                title={`${copy.DELETE} ${copy.DEVICE}`.toUpperCase()}
+                confirm
+                small
+                inProgress={this.state.inProgressDelete}
+                itemToDeleteTitle={`${copy.DEVICE} ${device.dev_id || ''}`}
+                onConfirm={this._deleteDevice}
+                onDeny={this._cancelDeleteDevice}
+                style={styles.deleteDeviceButton}
+              />
 
             </ScrollView>}
       </View>
@@ -312,10 +313,8 @@ const styles = StyleSheet.create({
     marginTop: 10,
   },
   deleteDeviceButton: {
-    alignSelf: 'flex-start',
-    marginTop: 30,
-    marginBottom: 50,
-    marginLeft: 10,
+    alignSelf: 'center',
+    marginVertical: 30,
   },
   clipBoardRow: {
     flexDirection: 'row',
@@ -325,9 +324,10 @@ const styles = StyleSheet.create({
     marginTop: 10,
   },
   submitButton: {
-    width: BUTTON_SIZE * 4,
+    width: BUTTON_SIZE * 3,
     height: BUTTON_SIZE,
-    alignSelf: 'center',
+    alignSelf: 'flex-end',
+    marginTop: 30,
     marginBottom: 15,
   },
 })


### PR DESCRIPTION
- Move all DeleteButtons to bottom of settings screen, switch to small format button.
- GatewaySettings -- if no map location has been selected, do not display a pin, also zoom out to show entire US (we could use user location as default centerpoint in the future)
- Align all submit buttons to `flex-end` instead of `center` to more closely match web

Closes #153