### PR TITLE
[Gateway, Applications] Use user location to set router/handler/initial map location

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <uses-sdk
         android:minSdkVersion="16"

--- a/src/components/ApplicationForm.js
+++ b/src/components/ApplicationForm.js
@@ -23,7 +23,7 @@ import SubmitButton from '../components/SubmitButton'
 import * as TTNApplicationActions from '../scopes/content/applications/actions'
 import { handlers } from '../constants/application'
 import { connect } from 'react-redux'
-import _ from 'lodash'
+import { getClosestOption } from '../utils/locationUtils'
 
 const BUTTON_SIZE = 60
 
@@ -50,8 +50,16 @@ class ApplicationForm extends Component {
     id: '',
     idValid: false,
     inProgress: false,
-    handler: 'ttn-handler-us-west',
+    handler: handlers[0].value,
   }
+  componentDidMount() {
+    navigator.geolocation.getCurrentPosition(position => {
+      this.setState({
+        handler: getClosestOption(position.coords, handlers).value,
+      })
+    })
+  }
+
   _onChangeText = (text, formInputId) => {
     switch (formInputId) {
       case 'applicationId':
@@ -132,7 +140,7 @@ class ApplicationForm extends Component {
             secondaryText="Select the handler you want to register this application to"
           />
           <RadioButtonPanel
-            buttons={_.map(handlers)}
+            buttons={handlers}
             selected={this.state.handler}
             onSelect={handler => this.setState({ handler })}
           />

--- a/src/constants/application.js
+++ b/src/constants/application.js
@@ -1,5 +1,7 @@
 //@flow
 
+import { ASIA_SE, EU, US_WEST, BRAZIL, NONE, locations } from './location'
+
 // Rights
 export const COLLABORATORS = 'collaborators'
 export const DELETE = 'delete'
@@ -13,25 +15,36 @@ export const OTAA = 'OTAA'
 export const ABP = 'ABP'
 
 // Handlers
-export const ASIA_SE = {
+const asiaSeHandler = {
   label: 'asia-se',
   value: 'ttn-handler-asia-se',
+  location: locations[ASIA_SE],
 }
-export const BRAZIL = {
+const brazilHandler = {
   label: 'brazil',
   value: 'ttn-handler-brazil',
+  location: locations[BRAZIL],
 }
-export const EU = { label: 'eu', value: 'ttn-handler-eu' }
-export const US_WEST = {
+const euHandler = {
+  label: 'eu',
+  value: 'ttn-handler-eu',
+  location: locations[EU],
+}
+const usWestHandler = {
   label: 'us-west',
   value: 'ttn-handler-us-west',
+  location: locations[US_WEST],
 }
-export const NONE = { label: 'none', value: '' }
+export const noneHandler = {
+  label: 'none',
+  value: '',
+  location: locations[NONE],
+}
 
-export const handlers = {
-  ASIA_SE,
-  BRAZIL,
-  EU,
-  US_WEST,
-  NONE,
-}
+export const handlers = [
+  asiaSeHandler,
+  brazilHandler,
+  euHandler,
+  usWestHandler,
+  noneHandler,
+]

--- a/src/constants/gateway.js
+++ b/src/constants/gateway.js
@@ -1,15 +1,41 @@
 //@flow
+import { ASIA_SE, EU, US_WEST, BRAZIL, locations } from './location'
+
 export const frequencyPlans = [
-  { label: 'Asia 920-923MHz', value: 'AS_920_923' },
-  { label: 'Asia 923-925MHz', value: 'AS_923_925' },
-  { label: 'Australia 915MHz', value: 'AU_915_928' },
-  { label: 'Europe 868MHz', value: 'EU_863_870' },
-  { label: 'United States 915MHz', value: 'US_902_928' },
+  {
+    label: 'Asia 920-923MHz',
+    value: 'AS_920_923',
+    location: locations[ASIA_SE],
+  },
+  {
+    label: 'Asia 923-925MHz',
+    value: 'AS_923_925',
+    location: locations[ASIA_SE],
+  },
+  {
+    label: 'Australia 915MHz',
+    value: 'AU_915_928',
+    location: locations[BRAZIL],
+  },
+  { label: 'Europe 868MHz', value: 'EU_863_870', location: locations[EU] },
+  {
+    label: 'United States 915MHz',
+    value: 'US_902_928',
+    location: locations[US_WEST],
+  },
 ]
 
 export const routers = [
-  { label: 'asia-se', value: 'ttn-router-asia-se' },
-  { label: 'brazil', value: 'ttn-router-brazil' },
-  { label: 'eu', value: 'ttn-router-eu' },
-  { label: 'us-west', value: 'ttn-router-us-west' },
+  {
+    label: 'asia-se',
+    value: 'ttn-router-asia-se',
+    location: locations[ASIA_SE],
+  },
+  { label: 'brazil', value: 'ttn-router-brazil', location: locations[BRAZIL] },
+  { label: 'eu', value: 'ttn-router-eu', location: locations[EU] },
+  {
+    label: 'us-west',
+    value: 'ttn-router-us-west',
+    location: locations[US_WEST],
+  },
 ]

--- a/src/constants/location.js
+++ b/src/constants/location.js
@@ -1,0 +1,31 @@
+//@flow
+
+export const US_WEST = 'us-west'
+export const EU = 'eu'
+export const BRAZIL = 'brazil'
+export const ASIA_SE = 'asia-se'
+export const NONE = 'none'
+
+// Locations are not precise
+export const locations = {
+  [BRAZIL]: {
+    latitude: -10.633336,
+    longitude: -52.458779,
+  },
+  [US_WEST]: {
+    latitude: 29.9103937,
+    longitude: -105.7463544,
+  },
+  [EU]: {
+    latitude: 50.753124,
+    longitude: 10.101663,
+  },
+  [ASIA_SE]: {
+    latitude: 16.333843,
+    longitude: 103.867667,
+  },
+  [NONE]: {
+    latitude: 0,
+    longitude: 0,
+  },
+}

--- a/src/scopes/content/gateways/types.js
+++ b/src/scopes/content/gateways/types.js
@@ -5,6 +5,20 @@ type Collaborator = {
   rights: Array<string>,
 }
 
+export type Coordinate = {
+  latitude: number,
+  longitude: number,
+}
+
+export type LocalizedOption = {
+  label: string,
+  value: string,
+  location: {
+    latitude: number,
+    longitude: number,
+  },
+}
+
 export type TTNGateway = {
   id: string,
   activated: boolean,

--- a/src/screens/ApplicationSettings.js
+++ b/src/screens/ApplicationSettings.js
@@ -34,7 +34,6 @@ import RadioButtonPanel from '../components/RadioButtonPanel'
 import SubmitButton from '../components/SubmitButton'
 import TagLabel from '../components/TagLabel'
 
-import _ from 'lodash'
 import { connect } from 'react-redux'
 import { applicationHasDeleteRights } from '../utils/permissionCheck'
 
@@ -399,7 +398,7 @@ class ApplicationSettings extends Component {
 
             <FormLabel primaryText="Handler" />
             <RadioButtonPanel
-              buttons={_.map(handlers)}
+              buttons={handlers}
               selected={this.state.handler}
               onSelect={handler => this.setState({ handler })}
             />

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -1,0 +1,47 @@
+//@flow
+import type {
+  Coordinate,
+  LocalizedOption,
+} from '../scopes/content/gateways/types'
+
+export function getDistanceFromCoords(
+  origin: Coordinate,
+  destination: Coordinate
+) {
+  var R = 6371 // Radius of the earth in km
+  var dLat = deg2rad(destination.latitude - origin.latitude) // deg2rad below
+  var dLon = deg2rad(destination.longitude - origin.longitude)
+  var a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(deg2rad(origin.latitude)) *
+      Math.cos(deg2rad(destination.latitude)) *
+      Math.sin(dLon / 2) *
+      Math.sin(dLon / 2)
+  var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  var d = R * c // Distance in km
+  return d
+}
+
+function deg2rad(deg) {
+  return deg * (Math.PI / 180)
+}
+
+export function getClosestOption(
+  userCoords: Coordinate,
+  options: Array<LocalizedOption>
+) {
+  let closestDistance
+  let closestOption
+  options.forEach((option, i) => {
+    const distanceFromOption = getDistanceFromCoords(
+      userCoords,
+      option.location
+    )
+    if (!closestDistance || distanceFromOption < closestDistance) {
+      closestDistance = distanceFromOption
+      closestOption = option
+    }
+  })
+  if (!closestOption) closestOption = options[0]
+  return closestOption
+}


### PR DESCRIPTION
- Adds helper util to get closest option from an array of `LocalizedOption`s (type containing `label`, `value`, `location`)

NOTE: Seeing a semi-transparent black overlay on android maps, only when embedded in modal form.

![screenshot](https://cloud.githubusercontent.com/assets/6730148/26173597/48388cc8-3b01-11e7-8cd1-0df8a29f1e38.jpg)


Closes #160