### PR TITLE
Revert "[android] Change package name for android (#144)"

### DIFF
--- a/android/app/BUCK
+++ b/android/app/BUCK
@@ -46,13 +46,13 @@ android_library(
 
 android_build_config(
   name = 'build_config',
-  package = 'com.async.ttn',
+  package = 'com.ttnconsole',
 )
 
 android_resource(
   name = 'res',
   res = 'src/main/res',
-  package = 'com.async.ttn',
+  package = 'com.ttnconsole',
 )
 
 android_binary(

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -122,7 +122,7 @@ android {
     def verCode = getVersionCode()
 
     defaultConfig {
-        applicationId "com.async.ttn"
+        applicationId "com.ttnconsole"
         minSdkVersion 16
         targetSdkVersion 22
         vectorDrawables.useSupportLibrary = true

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.async.ttn"
+    package="com.ttnconsole"
     android:versionCode="1"
     android:versionName="1.0">
 
@@ -45,7 +45,7 @@
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
 
         <meta-data
-            android:name="com.async.ttn.codePushKey"
+            android:name="com.ttnconsole.codePushKey"
             android:value="${CODE_PUSH_KEY}" />
 
         <meta-data

--- a/android/app/src/main/java/com/async/ttn/MainActivity.java
+++ b/android/app/src/main/java/com/async/ttn/MainActivity.java
@@ -1,4 +1,4 @@
-package com.async.ttn;
+package com.ttnconsole;
 
 import com.facebook.react.ReactActivity;
 

--- a/android/app/src/main/java/com/async/ttn/MainApplication.java
+++ b/android/app/src/main/java/com/async/ttn/MainApplication.java
@@ -1,4 +1,4 @@
-package com.async.ttn;
+package com.ttnconsole;
 
 import android.app.Application;
 import android.content.pm.ApplicationInfo;
@@ -56,7 +56,7 @@ public class MainApplication extends Application implements ReactApplication {
           new MainReactPackage(),
           new ImagePickerPackage(),
           new PickerPackage(),
-          new CodePush(metaData.getString("com.async.ttn.codePushKey"), getApplicationContext(), BuildConfig.DEBUG),
+          new CodePush(metaData.getString("com.ttnconsole.codePushKey"), getApplicationContext(), BuildConfig.DEBUG),
           new SvgPackage(),
           new RNSentryPackage(),
           new TTNMQTTPackage(),

--- a/android/app/src/main/java/com/async/ttn/TTNMQTTModule.java
+++ b/android/app/src/main/java/com/async/ttn/TTNMQTTModule.java
@@ -1,4 +1,4 @@
-package com.async.ttn;
+package com.ttnconsole;
 
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;

--- a/android/app/src/main/java/com/async/ttn/TTNMQTTPackage.java
+++ b/android/app/src/main/java/com/async/ttn/TTNMQTTPackage.java
@@ -1,4 +1,4 @@
-package com.async.ttn;
+package com.ttnconsole;
 
 import java.util.ArrayList;
 import java.util.Collections;


### PR DESCRIPTION
This reverts commit f094dc68ff3df8ad28015813dd073599ed51aa89.

com.async.ttn got suspended due to impersonation and I have no idea how long that might take to resolve.

This is the old package name that I used for alpha and is live. Shall we just move forward with this for now?