### PR TITLE
[CheckBox] Fix secondary text wrapping

### DIFF
--- a/src/components/CheckBox.js
+++ b/src/components/CheckBox.js
@@ -29,7 +29,7 @@ const CheckBox = ({
       <FormLabel
         primaryText={primaryText}
         secondaryText={secondaryText}
-        style={!secondaryText ? styles.oneLine : {}}
+        style={secondaryText ? styles.multiLine : styles.oneLine}
       />
     </TouchableOpacity>
   )
@@ -57,6 +57,12 @@ const styles = StyleSheet.create({
   },
   oneLine: {
     marginTop: undefined,
+    flexWrap: 'wrap',
+    flex: 1,
+  },
+  multiLine: {
+    flexWrap: 'wrap',
+    flex: 1,
   },
   option: {
     padding: 10,

--- a/src/components/FormLabel.js
+++ b/src/components/FormLabel.js
@@ -10,12 +10,15 @@ type Props = {
   primaryText: string,
   primaryTextStyle?: Object,
   secondaryText?: string,
-  style?: Object,
-};
+  style?: Object | Array<Object>,
+}
 
-const FormLabel = (
-  { primaryText, primaryTextStyle, secondaryText, style }: Props
-) => {
+const FormLabel = ({
+  primaryText,
+  primaryTextStyle,
+  secondaryText,
+  style,
+}: Props) => {
   return (
     <View style={[styles.container, style]}>
       <Text style={[styles.descriptionPrimary, primaryTextStyle]}>


### PR DESCRIPTION
Note: still see some wrapping issues when reloading the simulator on GatewaySettings page, but not when using the app normally and navigating to GatewaySettings. Maybe has to do with the order of layout rendering on refresh?

Closes #174