### PR TITLE
[Android] Adjust FB SDK Version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -196,7 +196,7 @@ dependencies {
     compile project(':react-native-vector-icons')
 
     // Facebook SDK
-    compile 'com.facebook.android:facebook-android-sdk:4.+'
+    compile 'com.facebook.android:facebook-android-sdk:4.22.1'
 
     // Paho MQTT
     compile 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.1.0'


### PR DESCRIPTION
Latest version of FB Android SDK has a bug causing builds to fail. This PR hardsets the previous version.